### PR TITLE
feat: Add max execution time per scan to prevent runaway scans #10

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,0 +1,87 @@
+# GasGuard API
+
+Nest.js backend handling remote scan requests with timeout protection.
+
+## Features
+
+- **Timeout Protection**: Prevents runaway scans from degrading system performance
+- **Configurable Timeouts**: Set max execution time via environment variables
+- **Worker Thread Support**: Optional worker-based scanning for additional isolation
+- **Clear Error Messages**: Graceful failure with descriptive timeout errors
+
+## Configuration
+
+Set the maximum execution time for scans via environment variable:
+
+```bash
+SCAN_MAX_EXECUTION_TIME_MS=30000  # 30 seconds (default)
+```
+
+## Usage
+
+### Basic Scan Endpoint
+
+```bash
+POST /scan
+Content-Type: application/json
+
+{
+  "contractCode": "contract code here...",
+  "timeoutMs": 30000  # optional, overrides default
+}
+```
+
+### Response
+
+**Success:**
+```json
+{
+  "scanId": "scan_1234567890_abc123",
+  "status": "completed",
+  "findings": [],
+  "executionTime": 1234567890
+}
+```
+
+**Timeout Error:**
+```json
+{
+  "statusCode": 408,
+  "message": "Scan exceeded maximum execution time. Scan exceeded maximum execution time of 30000ms",
+  "error": {
+    "code": "SCAN_TIMEOUT",
+    "message": "Scan exceeded maximum execution time of 30000ms",
+    "scanId": "scan_1234567890_abc123",
+    "timeoutMs": 30000
+  }
+}
+```
+
+## Implementation Details
+
+### Promise.race Approach (Default)
+
+The `ScanService` uses `Promise.race()` to enforce timeouts:
+
+```typescript
+const timeoutPromise = new Promise((_, reject) => {
+  setTimeout(() => reject(timeoutError), timeoutMs);
+});
+const result = await Promise.race([scanPromise, timeoutPromise]);
+```
+
+### Worker Thread Approach (Optional)
+
+For additional isolation, use `WorkerScanService` which runs scans in worker threads:
+
+- Prevents blocking the main event loop
+- Automatic cleanup on timeout via `worker.terminate()`
+- Better resource isolation
+
+## Error Handling
+
+All timeout errors include:
+- `code`: "SCAN_TIMEOUT"
+- `message`: Descriptive error message
+- `scanId`: Unique identifier for tracking
+- `timeoutMs`: The timeout value that was exceeded

--- a/apps/api/TIMEOUT_IMPLEMENTATION.md
+++ b/apps/api/TIMEOUT_IMPLEMENTATION.md
@@ -1,0 +1,168 @@
+# Timeout Implementation Guide
+
+## Overview
+
+This implementation prevents runaway scans from degrading system performance by enforcing maximum execution time limits per scan operation.
+
+## Implementation Approaches
+
+### 1. Promise.race Approach (Primary - ScanService)
+
+**Location:** `src/scan/scan.service.ts`
+
+**How it works:**
+- Uses `Promise.race()` to compete a scan promise against a timeout promise
+- If the timeout promise resolves first, the scan is terminated with a clear error
+- Lightweight and doesn't require additional processes
+
+**Usage:**
+```typescript
+const result = await scanService.executeScan(contractCode, {
+  timeoutMs: 30000 // optional, defaults to config value
+});
+```
+
+**Error Handling:**
+```typescript
+try {
+  const result = await scanService.executeScan(contractCode);
+} catch (error) {
+  if (error.code === 'SCAN_TIMEOUT') {
+    console.error(`Scan timed out after ${error.timeoutMs}ms`);
+  }
+}
+```
+
+### 2. Worker Thread Approach (Optional - WorkerScanService)
+
+**Location:** `src/scan/worker-scan.service.ts`
+
+**How it works:**
+- Runs scans in isolated worker threads
+- Automatically terminates workers that exceed timeout
+- Provides better isolation and prevents blocking the main event loop
+- More resource-intensive but safer for long-running operations
+
+**Usage:**
+```typescript
+// Add WorkerScanService to ScanModule providers
+const result = await workerScanService.executeScanInWorker(contractCode, {
+  timeoutMs: 30000
+});
+```
+
+**Benefits:**
+- Complete isolation from main process
+- Automatic cleanup via `worker.terminate()`
+- Prevents event loop blocking
+
+## Configuration
+
+### Environment Variables
+
+Set the default maximum execution time:
+
+```bash
+# .env or .env.local
+SCAN_MAX_EXECUTION_TIME_MS=30000  # 30 seconds (default)
+```
+
+### Per-Scan Override
+
+You can override the timeout for individual scans:
+
+```typescript
+// Use custom timeout for this specific scan
+await scanService.executeScan(contractCode, {
+  timeoutMs: 60000 // 60 seconds
+});
+```
+
+## Error Response Format
+
+### Timeout Error Structure
+
+```typescript
+{
+  code: 'SCAN_TIMEOUT',
+  message: 'Scan exceeded maximum execution time of 30000ms',
+  scanId: 'scan_1234567890_abc123',
+  timeoutMs: 30000
+}
+```
+
+### HTTP Response (408 Request Timeout)
+
+```json
+{
+  "statusCode": 408,
+  "message": "Scan exceeded maximum execution time. Scan exceeded maximum execution time of 30000ms",
+  "error": {
+    "code": "SCAN_TIMEOUT",
+    "message": "Scan exceeded maximum execution time of 30000ms",
+    "scanId": "scan_1234567890_abc123",
+    "timeoutMs": 30000
+  }
+}
+```
+
+## Integration Points
+
+### Current Implementation
+
+1. **ScanService** (`src/scan/scan.service.ts`)
+   - Primary service using Promise.race
+   - Used by ScanController
+
+2. **WorkerScanService** (`src/scan/worker-scan.service.ts`)
+   - Optional worker-based implementation
+   - Can be added to ScanModule if needed
+
+3. **ScanController** (`src/scan/scan.controller.ts`)
+   - HTTP endpoint: `POST /scan`
+   - Handles timeout errors with 408 status code
+   - Validates input before starting scan
+
+## Testing Timeout Behavior
+
+### Unit Test Example
+
+See `src/scan/scan.service.spec.ts` for examples of:
+- Testing successful scans
+- Testing timeout scenarios
+- Testing custom timeout values
+
+### Manual Testing
+
+To test timeout behavior, you can simulate a long-running scan:
+
+```typescript
+// In performScan method, add a delay longer than timeout
+await new Promise(resolve => setTimeout(resolve, 40000)); // 40 seconds
+// Then call with 30 second timeout - should fail
+```
+
+## Best Practices
+
+1. **Set Reasonable Defaults**: 30 seconds is a good default, but adjust based on:
+   - Average contract complexity
+   - System resources
+   - User expectations
+
+2. **Log Timeouts**: All timeouts are logged with scan ID for debugging
+
+3. **Monitor Timeout Frequency**: If many scans timeout, consider:
+   - Increasing default timeout
+   - Optimizing scan algorithms
+   - Using worker threads for better isolation
+
+4. **Graceful Degradation**: Timeout errors are clearly communicated to users
+
+## Done Criteria ✅
+
+- ✅ Scans exceeding limit fail gracefully with clear error
+- ✅ Uses Node.js process timeout (Promise.race)
+- ✅ Provides worker constraints option (WorkerScanService)
+- ✅ Configurable via environment variables
+- ✅ Per-scan timeout override supported
+- ✅ Comprehensive error handling and logging

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@gasguard/api",
+  "version": "1.0.0",
+  "description": "GasGuard API - Nest.js backend handling remote scan requests",
+  "main": "dist/main.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/main.js",
+    "start:dev": "ts-node-dev --respawn --transpile-only src/main.ts",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/config": "^3.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
+    "@types/jest": "^29.0.0",
+    "jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
+    "ts-node": "^10.9.0",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { ScanModule } from './scan/scan.module';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      envFilePath: ['.env.local', '.env'],
+    }),
+    ScanModule,
+  ],
+})
+export class AppModule {}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,0 +1,25 @@
+import { NestFactory } from '@nestjs/core';
+import { ValidationPipe } from '@nestjs/common';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+
+  // Enable validation
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
+
+  // Enable CORS if needed
+  app.enableCors();
+
+  const port = process.env.PORT || 3000;
+  await app.listen(port);
+  console.log(`GasGuard API is running on: http://localhost:${port}`);
+}
+
+bootstrap();

--- a/apps/api/src/scan/interfaces/scan.interface.ts
+++ b/apps/api/src/scan/interfaces/scan.interface.ts
@@ -1,0 +1,39 @@
+/**
+ * Result of a contract scan operation
+ */
+export interface ScanResult {
+  scanId: string;
+  status: 'completed' | 'failed' | 'timeout';
+  findings: ScanFinding[];
+  executionTime: number;
+  metadata?: {
+    contractSize?: number;
+    rulesApplied?: string[];
+  };
+}
+
+/**
+ * Individual finding from a scan
+ */
+export interface ScanFinding {
+  ruleId: string;
+  severity: 'error' | 'warning' | 'info';
+  message: string;
+  location?: {
+    line: number;
+    column: number;
+    file?: string;
+  };
+  suggestion?: string;
+}
+
+/**
+ * Error structure for scan failures
+ */
+export interface ScanError {
+  code: 'SCAN_TIMEOUT' | 'SCAN_ERROR' | 'INVALID_INPUT';
+  message: string;
+  scanId?: string;
+  timeoutMs?: number;
+  details?: unknown;
+}

--- a/apps/api/src/scan/scan.controller.ts
+++ b/apps/api/src/scan/scan.controller.ts
@@ -1,0 +1,90 @@
+import {
+  Controller,
+  Post,
+  Body,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  BadRequestException,
+  RequestTimeoutException,
+} from '@nestjs/common';
+import { ScanService } from './scan.service';
+import { ScanResult, ScanError } from './interfaces/scan.interface';
+
+interface ScanRequestDto {
+  contractCode: string;
+  timeoutMs?: number;
+  options?: Record<string, unknown>;
+}
+
+@Controller('scan')
+export class ScanController {
+  private readonly logger = new Logger(ScanController.name);
+
+  constructor(private readonly scanService: ScanService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.OK)
+  async scanContract(
+    @Body() scanRequest: ScanRequestDto,
+  ): Promise<ScanResult | { error: ScanError }> {
+    try {
+      // Validate input
+      if (!scanRequest.contractCode || typeof scanRequest.contractCode !== 'string') {
+        throw new BadRequestException({
+          code: 'INVALID_INPUT',
+          message: 'contractCode is required and must be a string',
+        });
+      }
+
+      if (scanRequest.contractCode.length === 0) {
+        throw new BadRequestException({
+          code: 'INVALID_INPUT',
+          message: 'contractCode cannot be empty',
+        });
+      }
+
+      this.logger.log(
+        `Received scan request (code length: ${scanRequest.contractCode.length} chars)`,
+      );
+
+      // Execute scan with timeout protection
+      const result = await this.scanService.executeScan(
+        scanRequest.contractCode,
+        {
+          timeoutMs: scanRequest.timeoutMs,
+        },
+      );
+
+      return result;
+    } catch (error) {
+      this.logger.error('Scan request failed:', error);
+
+      // Handle timeout errors specifically
+      if (
+        error &&
+        typeof error === 'object' &&
+        'code' in error &&
+        error.code === 'SCAN_TIMEOUT'
+      ) {
+        throw new RequestTimeoutException({
+          error: error as ScanError,
+          message: `Scan exceeded maximum execution time. ${error.message}`,
+        });
+      }
+
+      // Handle validation errors
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
+
+      // Handle other errors
+      throw {
+        error: {
+          code: 'SCAN_ERROR',
+          message: error instanceof Error ? error.message : 'Unknown error occurred',
+        } as ScanError,
+      };
+    }
+  }
+}

--- a/apps/api/src/scan/scan.module.ts
+++ b/apps/api/src/scan/scan.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { ScanController } from './scan.controller';
+import { ScanService } from './scan.service';
+
+@Module({
+  imports: [ConfigModule],
+  controllers: [ScanController],
+  providers: [ScanService],
+  exports: [ScanService],
+})
+export class ScanModule {}

--- a/apps/api/src/scan/scan.service.spec.ts
+++ b/apps/api/src/scan/scan.service.spec.ts
@@ -1,0 +1,95 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { ScanService } from './scan.service';
+import { ScanError } from './interfaces/scan.interface';
+
+describe('ScanService', () => {
+  let service: ScanService;
+  let configService: ConfigService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ScanService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) => {
+              if (key === 'SCAN_MAX_EXECUTION_TIME_MS') {
+                return 1000; // 1 second for testing
+              }
+              return undefined;
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<ScanService>(ScanService);
+    configService = module.get<ConfigService>(ConfigService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should complete scan within timeout', async () => {
+    const result = await service.executeScan('contract code');
+    expect(result).toBeDefined();
+    expect(result.scanId).toBeDefined();
+    expect(result.status).toBe('completed');
+  });
+
+  it('should timeout when scan exceeds max execution time', async () => {
+    // Mock performScan to take longer than timeout
+    jest.spyOn(service as any, 'performScan').mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({
+              scanId: 'test',
+              status: 'completed',
+              findings: [],
+              executionTime: Date.now(),
+            });
+          }, 2000); // 2 seconds, longer than 1 second timeout
+        }),
+    );
+
+    await expect(
+      service.executeScan('contract code', { timeoutMs: 1000 }),
+    ).rejects.toMatchObject({
+      code: 'SCAN_TIMEOUT',
+      message: expect.stringContaining('exceeded maximum execution time'),
+    });
+  });
+
+  it('should use default timeout from config', () => {
+    const maxTime = service.getMaxExecutionTime();
+    expect(maxTime).toBe(1000);
+  });
+
+  it('should allow custom timeout per scan', async () => {
+    const customTimeout = 500;
+    jest.spyOn(service as any, 'performScan').mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({
+              scanId: 'test',
+              status: 'completed',
+              findings: [],
+              executionTime: Date.now(),
+            });
+          }, 1000); // 1 second, longer than custom 500ms timeout
+        }),
+    );
+
+    await expect(
+      service.executeScan('contract code', { timeoutMs: customTimeout }),
+    ).rejects.toMatchObject({
+      code: 'SCAN_TIMEOUT',
+      timeoutMs: customTimeout,
+    });
+  });
+});

--- a/apps/api/src/scan/scan.service.ts
+++ b/apps/api/src/scan/scan.service.ts
@@ -1,0 +1,113 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ScanResult, ScanError } from './interfaces/scan.interface';
+
+@Injectable()
+export class ScanService {
+  private readonly logger = new Logger(ScanService.name);
+  private readonly maxExecutionTime: number;
+
+  constructor(private configService: ConfigService) {
+    // Default to 30 seconds, configurable via environment variable
+    this.maxExecutionTime =
+      this.configService.get<number>('SCAN_MAX_EXECUTION_TIME_MS') || 30000;
+    this.logger.log(
+      `Scan service initialized with max execution time: ${this.maxExecutionTime}ms`,
+    );
+  }
+
+  /**
+   * Executes a scan with timeout protection
+   * @param contractCode The contract code to scan
+   * @param options Optional scan options
+   * @returns Promise resolving to scan results or rejecting with timeout error
+   */
+  async executeScan(
+    contractCode: string,
+    options?: ScanOptions,
+  ): Promise<ScanResult> {
+    const timeoutMs = options?.timeoutMs || this.maxExecutionTime;
+    const scanId = options?.scanId || this.generateScanId();
+
+    this.logger.log(`Starting scan ${scanId} with timeout: ${timeoutMs}ms`);
+
+    // Create a timeout promise that will reject after the max execution time
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      setTimeout(() => {
+        const error: ScanError = {
+          code: 'SCAN_TIMEOUT',
+          message: `Scan exceeded maximum execution time of ${timeoutMs}ms`,
+          scanId,
+          timeoutMs,
+        };
+        this.logger.warn(
+          `Scan ${scanId} timed out after ${timeoutMs}ms`,
+        );
+        reject(error);
+      }, timeoutMs);
+    });
+
+    // Create the actual scan promise
+    const scanPromise = this.performScan(contractCode, scanId);
+
+    // Race between the scan and timeout
+    try {
+      const result = await Promise.race([scanPromise, timeoutPromise]);
+      this.logger.log(`Scan ${scanId} completed successfully`);
+      return result;
+    } catch (error) {
+      // If it's a timeout error, re-throw it
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'SCAN_TIMEOUT') {
+        throw error;
+      }
+      // Otherwise, wrap other errors
+      this.logger.error(`Scan ${scanId} failed with error:`, error);
+      throw {
+        code: 'SCAN_ERROR',
+        message: error instanceof Error ? error.message : 'Unknown scan error',
+        scanId,
+      } as ScanError;
+    }
+  }
+
+  /**
+   * Performs the actual scan operation
+   * This is where the contract analysis logic would be implemented
+   */
+  private async performScan(
+    contractCode: string,
+    scanId: string,
+  ): Promise<ScanResult> {
+    // Simulate scan work - in real implementation, this would call the engine
+    // For now, we'll add a small delay to demonstrate the timeout mechanism
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // TODO: Integrate with actual analysis engine
+    // This is a placeholder that would be replaced with actual contract analysis
+    return {
+      scanId,
+      status: 'completed',
+      findings: [],
+      executionTime: Date.now(),
+    };
+  }
+
+  /**
+   * Generates a unique scan ID for tracking
+   */
+  private generateScanId(): string {
+    return `scan_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+  }
+
+  /**
+   * Gets the current max execution time configuration
+   */
+  getMaxExecutionTime(): number {
+    return this.maxExecutionTime;
+  }
+}
+
+export interface ScanOptions {
+  timeoutMs?: number;
+  scanId?: string;
+}

--- a/apps/api/src/scan/worker-scan.service.ts
+++ b/apps/api/src/scan/worker-scan.service.ts
@@ -1,0 +1,134 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Worker } from 'worker_threads';
+import { join } from 'path';
+import { ScanResult, ScanError } from '../scan/interfaces/scan.interface';
+
+/**
+ * Worker-based scan service that provides additional isolation
+ * for long-running scans. Uses Node.js worker threads to prevent
+ * blocking the main event loop.
+ */
+@Injectable()
+export class WorkerScanService {
+  private readonly logger = new Logger(WorkerScanService.name);
+  private readonly maxExecutionTime: number;
+
+  constructor(private configService: ConfigService) {
+    this.maxExecutionTime =
+      this.configService.get<number>('SCAN_MAX_EXECUTION_TIME_MS') || 30000;
+    this.logger.log(
+      `Worker scan service initialized with max execution time: ${this.maxExecutionTime}ms`,
+    );
+  }
+
+  /**
+   * Executes a scan in a worker thread with timeout protection
+   * @param contractCode The contract code to scan
+   * @param options Optional scan options
+   * @returns Promise resolving to scan results or rejecting with timeout error
+   */
+  async executeScanInWorker(
+    contractCode: string,
+    options?: { timeoutMs?: number; scanId?: string },
+  ): Promise<ScanResult> {
+    const timeoutMs = options?.timeoutMs || this.maxExecutionTime;
+    const scanId = options?.scanId || this.generateScanId();
+
+    this.logger.log(
+      `Starting worker scan ${scanId} with timeout: ${timeoutMs}ms`,
+    );
+
+    return new Promise<ScanResult>((resolve, reject) => {
+      // Create worker thread
+      // In production, use compiled .js file; in development, use .ts with ts-node
+      const isProduction = process.env.NODE_ENV === 'production';
+      const workerPath = isProduction
+        ? join(__dirname, 'workers', 'scan.worker.js')
+        : join(__dirname, 'workers', 'scan.worker.ts');
+      const worker = new Worker(workerPath, {
+        workerData: { contractCode, scanId },
+        ...(isProduction ? {} : { execArgv: ['-r', 'ts-node/register'] }),
+      });
+
+      let isResolved = false;
+
+      // Set up timeout
+      const timeout = setTimeout(() => {
+        if (!isResolved) {
+          isResolved = true;
+          worker.terminate(); // Force terminate the worker
+          const error: ScanError = {
+            code: 'SCAN_TIMEOUT',
+            message: `Worker scan exceeded maximum execution time of ${timeoutMs}ms`,
+            scanId,
+            timeoutMs,
+          };
+          this.logger.warn(`Worker scan ${scanId} timed out after ${timeoutMs}ms`);
+          reject(error);
+        }
+      }, timeoutMs);
+
+      // Handle worker messages
+      worker.on('message', (result: ScanResult | ScanError) => {
+        if (!isResolved) {
+          isResolved = true;
+          clearTimeout(timeout);
+
+          if ('code' in result && result.code) {
+            // It's an error
+            this.logger.error(`Worker scan ${scanId} failed:`, result);
+            reject(result as ScanError);
+          } else {
+            // It's a successful result
+            this.logger.log(`Worker scan ${scanId} completed successfully`);
+            resolve(result as ScanResult);
+          }
+        }
+      });
+
+      // Handle worker errors
+      worker.on('error', (error) => {
+        if (!isResolved) {
+          isResolved = true;
+          clearTimeout(timeout);
+          this.logger.error(`Worker scan ${scanId} encountered an error:`, error);
+          reject({
+            code: 'SCAN_ERROR',
+            message: error.message,
+            scanId,
+            details: error,
+          } as ScanError);
+        }
+      });
+
+      // Handle worker exit
+      worker.on('exit', (code) => {
+        if (!isResolved && code !== 0) {
+          isResolved = true;
+          clearTimeout(timeout);
+          this.logger.error(`Worker scan ${scanId} exited with code ${code}`);
+          reject({
+            code: 'SCAN_ERROR',
+            message: `Worker exited unexpectedly with code ${code}`,
+            scanId,
+          } as ScanError);
+        }
+      });
+    });
+  }
+
+  /**
+   * Generates a unique scan ID for tracking
+   */
+  private generateScanId(): string {
+    return `worker_scan_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+  }
+
+  /**
+   * Gets the current max execution time configuration
+   */
+  getMaxExecutionTime(): number {
+    return this.maxExecutionTime;
+  }
+}

--- a/apps/api/src/scan/workers/scan.worker.ts
+++ b/apps/api/src/scan/workers/scan.worker.ts
@@ -1,0 +1,62 @@
+import { parentPort, workerData } from 'worker_threads';
+import { ScanResult, ScanError } from '../interfaces/scan.interface';
+
+/**
+ * Worker thread implementation for contract scanning
+ * This runs in isolation from the main process, preventing
+ * long-running scans from blocking the event loop
+ */
+
+interface WorkerData {
+  contractCode: string;
+  scanId: string;
+}
+
+async function performScan(): Promise<void> {
+  try {
+    const { contractCode, scanId } = workerData as WorkerData;
+
+    if (!parentPort) {
+      throw new Error('Worker must be run in a worker thread context');
+    }
+
+    // TODO: Integrate with actual analysis engine
+    // This is a placeholder that would be replaced with actual contract analysis
+    // For demonstration, we simulate some work
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const result: ScanResult = {
+      scanId,
+      status: 'completed',
+      findings: [],
+      executionTime: Date.now(),
+    };
+
+    // Send result back to main thread
+    parentPort.postMessage(result);
+  } catch (error) {
+    const errorResult: ScanError = {
+      code: 'SCAN_ERROR',
+      message: error instanceof Error ? error.message : 'Unknown error in worker',
+      scanId: (workerData as WorkerData).scanId,
+      details: error,
+    };
+
+    if (parentPort) {
+      parentPort.postMessage(errorResult);
+    }
+  }
+}
+
+// Start the scan when worker is initialized
+performScan().catch((error) => {
+  const errorResult: ScanError = {
+    code: 'SCAN_ERROR',
+    message: error instanceof Error ? error.message : 'Fatal error in worker',
+    details: error,
+  };
+
+  if (parentPort) {
+    parentPort.postMessage(errorResult);
+  }
+});

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2021",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true,
+    "strictNullChecks": false,
+    "noImplicitAny": false,
+    "strictBindCallApply": false,
+    "forceConsistentCasingInFileNames": false,
+    "noFallthroughCasesInSwitch": false,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "lib": ["ES2021"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Closes #10   
# Impact
Prevents runaway scans from degrading system performance. Some contracts may hang analyzers, so this adds timeout protection.

## Changes
- ✅ Implement `ScanService` with `Promise.race` timeout mechanism
- ✅ Add `WorkerScanService` for worker thread isolation (optional)
- ✅ Create `POST /scan` endpoint with timeout protection
- ✅ Add configurable timeout via `SCAN_MAX_EXECUTION_TIME_MS` env var
- ✅ Implement graceful timeout error handling with clear messages
- ✅ Add unit tests for timeout scenarios
- ✅ Include comprehensive documentation

## Implementation Details
- Uses Node.js `Promise.race()` for lightweight timeout enforcement
- Provides optional worker thread implementation for better isolation
- Default timeout: 30 seconds (configurable)
- Scans exceeding limit fail gracefully with clear error messages

## Testing
- Unit tests included in `scan.service.spec.ts`
- Tests cover successful scans, timeout scenarios, and custom timeouts

## Done Criteria
✅ Scans exceeding limit fail gracefully with clear error
✅ Uses Node.js process timeout (Promise.race)
✅ Provides worker constraints option
✅ Configurable via environment variables