### PR TITLE
feat(vyper): Add detector for redundant @external decorators

### DIFF
--- a/examples/redundant_external.vy
+++ b/examples/redundant_external.vy
@@ -1,0 +1,71 @@
+# @version ^0.3.0
+
+# Example Vyper contract demonstrating redundant @external decorators
+# This file contains violations that GasGuard should detect
+
+# Storage variables
+owner: public(address)
+balance: public(uint256)
+fee_rate: uint256
+
+@external
+def __init__():
+    """Initialize the contract - legitimate @external"""
+    self.owner = msg.sender
+    self.balance = 0
+    self.fee_rate = 30  # 0.3%
+
+# VIOLATION 1: Internal naming convention with @external
+# Functions starting with _ should be @internal
+@external
+def _calculate_fee(amount: uint256) -> uint256:
+    """This function uses internal naming convention but is marked external"""
+    return amount * self.fee_rate / 10000
+
+# VIOLATION 2: Another internal-named function with @external
+@external
+def _validate_amount(amount: uint256) -> bool:
+    """Validation helper that should be internal"""
+    return amount > 0 and amount <= self.balance
+
+# CORRECT: Properly marked internal function
+@internal
+def _update_balance(new_balance: uint256):
+    """Internal helper - correctly marked"""
+    self.balance = new_balance
+
+# CORRECT: Legitimate external function
+@external
+def deposit():
+    """Public deposit function - legitimate @external"""
+    self.balance += msg.value
+
+# CORRECT: Legitimate external function
+@external
+def withdraw(amount: uint256):
+    """Public withdraw function - legitimate @external"""
+    assert self._validate_amount(amount), "Invalid amount"
+    fee: uint256 = self._calculate_fee(amount)
+    self._update_balance(self.balance - amount)
+    send(msg.sender, amount - fee)
+
+# VIOLATION 3: Helper function only called internally
+@external
+def calculate_withdrawal_fee(amount: uint256) -> uint256:
+    """This is only called internally but marked external"""
+    return self._calculate_fee(amount)
+
+# CORRECT: View function for external queries
+@external
+@view
+def get_balance() -> uint256:
+    """External view function - legitimate @external"""
+    return self.balance
+
+# CORRECT: External function with proper visibility
+@external
+def transfer(to: address, amount: uint256):
+    """Transfer function - legitimate @external"""
+    assert self._validate_amount(amount), "Invalid amount"
+    self._update_balance(self.balance - amount)
+    send(to, amount)

--- a/libs/engine/Cargo.toml
+++ b/libs/engine/Cargo.toml
@@ -11,3 +11,5 @@ serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 anyhow = "1.0"
 colored = "2.0"
+chrono = { version = "0.4", features = ["serde"] }
+walkdir = "2.0"

--- a/libs/engine/src/analyzer.rs
+++ b/libs/engine/src/analyzer.rs
@@ -1,5 +1,5 @@
-use gasguard_rules::{RuleViolation, ViolationSeverity};
 use colored::*;
+use gasguard_rules::{RuleViolation, ViolationSeverity};
 use std::fmt;
 
 pub struct ScanAnalyzer;
@@ -7,12 +7,14 @@ pub struct ScanAnalyzer;
 impl ScanAnalyzer {
     pub fn format_violations(violations: &[RuleViolation]) -> String {
         if violations.is_empty() {
-            return "✅ No violations found! Your contract is optimized.".green().to_string();
+            return "✅ No violations found! Your contract is optimized."
+                .green()
+                .to_string();
         }
-        
+
         let mut output = String::new();
         let (errors, warnings, info) = Self::categorize_violations(violations);
-        
+
         if !errors.is_empty() {
             output.push_str(&format!("🚨 {} Errors:\n", errors.len()).red().bold());
             for violation in errors {
@@ -20,39 +22,46 @@ impl ScanAnalyzer {
             }
             output.push('\n');
         }
-        
+
         if !warnings.is_empty() {
-            output.push_str(&format!("⚠️  {} Warnings:\n", warnings.len()).yellow().bold());
+            output.push_str(
+                &format!("⚠️  {} Warnings:\n", warnings.len())
+                    .yellow()
+                    .bold(),
+            );
             for violation in warnings {
                 output.push_str(&Self::format_single_violation(violation, "WARNING"));
             }
             output.push('\n');
         }
-        
+
         if !info.is_empty() {
             output.push_str(&format!("ℹ️  {} Info:\n", info.len()).blue().bold());
             for violation in info {
                 output.push_str(&Self::format_single_violation(violation, "INFO"));
             }
         }
-        
+
         output
     }
-    
+
     pub fn generate_summary(violations: &[RuleViolation]) -> String {
         let total = violations.len();
         let (errors, warnings, info) = Self::categorize_violations(violations);
-        
+
         format!(
             "Scan Summary: {} total violations ({} errors, {} warnings, {} info)",
-            total, errors.len(), warnings.len(), info.len()
+            total,
+            errors.len(),
+            warnings.len(),
+            info.len()
         )
     }
-    
+
     pub fn calculate_storage_savings(violations: &[RuleViolation]) -> StorageSavings {
         let mut unused_vars = 0;
         let mut estimated_savings_kb = 0.0;
-        
+
         for violation in violations {
             if violation.rule_name == "unused-state-variables" {
                 unused_vars += 1;
@@ -61,19 +70,25 @@ impl ScanAnalyzer {
                 estimated_savings_kb += 2.5; // Average variable size in KB
             }
         }
-        
+
         StorageSavings {
             unused_variables: unused_vars,
             estimated_savings_kb,
             monthly_ledger_rent_savings: estimated_savings_kb * 0.001, // Rough estimate
         }
     }
-    
-    fn categorize_violations(violations: &[RuleViolation]) -> (Vec<&RuleViolation>, Vec<&RuleViolation>, Vec<&RuleViolation>) {
+
+    fn categorize_violations(
+        violations: &[RuleViolation],
+    ) -> (
+        Vec<&RuleViolation>,
+        Vec<&RuleViolation>,
+        Vec<&RuleViolation>,
+    ) {
         let mut errors = Vec::new();
         let mut warnings = Vec::new();
         let mut info = Vec::new();
-        
+
         for violation in violations {
             match violation.severity {
                 ViolationSeverity::Error => errors.push(violation),
@@ -81,10 +96,10 @@ impl ScanAnalyzer {
                 ViolationSeverity::Info => info.push(violation),
             }
         }
-        
+
         (errors, warnings, info)
     }
-    
+
     fn format_single_violation(violation: &RuleViolation, severity: &str) -> String {
         let severity_color = match severity {
             "ERROR" => colored::Color::Red,
@@ -92,7 +107,7 @@ impl ScanAnalyzer {
             "INFO" => colored::Color::Blue,
             _ => colored::Color::White,
         };
-        
+
         format!(
             "{}\n  📍 Line {}: {}\n  📝 {}\n  💡 {}\n\n",
             format!("  [{}]", severity).color(severity_color).bold(),

--- a/libs/engine/src/lib.rs
+++ b/libs/engine/src/lib.rs
@@ -1,5 +1,5 @@
-pub mod scanner;
 pub mod analyzer;
+pub mod scanner;
 
-pub use scanner::*;
 pub use analyzer::*;
+pub use scanner::*;

--- a/libs/engine/src/scanner.rs
+++ b/libs/engine/src/scanner.rs
@@ -1,58 +1,137 @@
-use gasguard_rules::{RuleEngine, UnusedStateVariablesRule};
+use anyhow::{Context, Result};
+use gasguard_rules::{RuleEngine, UnusedStateVariablesRule, VyperRuleEngine};
 use std::path::Path;
-use anyhow::{Result, Context};
+
+/// Supported languages for scanning
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Language {
+    Rust,
+    Vyper,
+}
+
+impl Language {
+    /// Detect language from file extension
+    pub fn from_extension(ext: &str) -> Option<Self> {
+        match ext.to_lowercase().as_str() {
+            "rs" => Some(Language::Rust),
+            "vy" => Some(Language::Vyper),
+            _ => None,
+        }
+    }
+}
 
 pub struct ContractScanner {
     rule_engine: RuleEngine,
+    vyper_rule_engine: VyperRuleEngine,
 }
 
 impl ContractScanner {
     pub fn new() -> Self {
-        let rule_engine = RuleEngine::new()
-            .add_rule(Box::new(UnusedStateVariablesRule));
-            
-        Self { rule_engine }
+        let rule_engine = RuleEngine::new().add_rule(Box::new(UnusedStateVariablesRule));
+        let vyper_rule_engine = VyperRuleEngine::with_default_rules();
+
+        Self {
+            rule_engine,
+            vyper_rule_engine,
+        }
     }
-    
+
     pub fn scan_file(&self, file_path: &Path) -> Result<ScanResult> {
         let content = std::fs::read_to_string(file_path)
             .with_context(|| format!("Failed to read file: {:?}", file_path))?;
-            
-        self.scan_content(&content, file_path.to_string_lossy().to_string())
+
+        let extension = file_path.extension().and_then(|e| e.to_str()).unwrap_or("");
+
+        let language = Language::from_extension(extension);
+
+        self.scan_content_with_language(&content, file_path.to_string_lossy().to_string(), language)
     }
-    
+
     pub fn scan_content(&self, content: &str, source: String) -> Result<ScanResult> {
-        let violations = self.rule_engine.analyze(content)
-            .with_context(|| "Failed to analyze contract code")?;
-            
+        // Default to Rust for backward compatibility
+        self.scan_content_with_language(content, source, Some(Language::Rust))
+    }
+
+    pub fn scan_content_with_language(
+        &self,
+        content: &str,
+        source: String,
+        language: Option<Language>,
+    ) -> Result<ScanResult> {
+        let violations = match language {
+            Some(Language::Rust) => self
+                .rule_engine
+                .analyze(content)
+                .map_err(|e| anyhow::anyhow!(e))?,
+            Some(Language::Vyper) => self
+                .vyper_rule_engine
+                .analyze(content)
+                .map_err(|e| anyhow::anyhow!(e))?,
+            None => {
+                // Unknown language, return empty violations
+                Vec::new()
+            }
+        };
+
         Ok(ScanResult {
             source,
             violations,
             scan_time: chrono::Utc::now(),
         })
     }
-    
+
+    /// Scan a Vyper file specifically
+    pub fn scan_vyper_file(&self, file_path: &Path) -> Result<ScanResult> {
+        let content = std::fs::read_to_string(file_path)
+            .with_context(|| format!("Failed to read file: {:?}", file_path))?;
+
+        self.scan_vyper_content(&content, file_path.to_string_lossy().to_string())
+    }
+
+    /// Scan Vyper content directly
+    pub fn scan_vyper_content(&self, content: &str, source: String) -> Result<ScanResult> {
+        let violations = self
+            .vyper_rule_engine
+            .analyze(content)
+            .map_err(|e| anyhow::anyhow!(e))?;
+
+        Ok(ScanResult {
+            source,
+            violations,
+            scan_time: chrono::Utc::now(),
+        })
+    }
+
     pub fn scan_directory(&self, dir_path: &Path) -> Result<Vec<ScanResult>> {
         let mut results = Vec::new();
-        
+
         for entry in walkdir::WalkDir::new(dir_path)
             .into_iter()
             .filter_map(|e| e.ok())
             .filter(|e| {
-                e.path().extension().map_or(false, |ext| ext == "rs")
-            }) {
-            
+                e.path().extension().map_or(false, |ext| {
+                    let ext_str = ext.to_str().unwrap_or("");
+                    Language::from_extension(ext_str).is_some()
+                })
+            })
+        {
             let result = self.scan_file(entry.path())?;
             if !result.violations.is_empty() {
                 results.push(result);
             }
         }
-        
+
         Ok(results)
     }
 }
 
-#[derive(Debug, Clone)]
+impl Default for ContractScanner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct ScanResult {
     pub source: String,
     pub violations: Vec<gasguard_rules::RuleViolation>,
@@ -63,14 +142,17 @@ impl ScanResult {
     pub fn has_violations(&self) -> bool {
         !self.violations.is_empty()
     }
-    
-    pub fn get_violations_by_severity(&self, severity: gasguard_rules::ViolationSeverity) -> Vec<&gasguard_rules::RuleViolation> {
+
+    pub fn get_violations_by_severity(
+        &self,
+        severity: gasguard_rules::ViolationSeverity,
+    ) -> Vec<&gasguard_rules::RuleViolation> {
         self.violations
             .iter()
-            .filter(|v| matches!(v.severity, severity))
+            .filter(|v| std::mem::discriminant(&v.severity) == std::mem::discriminant(&severity))
             .collect()
     }
-    
+
     pub fn to_json(&self) -> Result<String, serde_json::Error> {
         serde_json::to_string_pretty(self)
     }

--- a/packages/rules/Cargo.toml
+++ b/packages/rules/Cargo.toml
@@ -10,3 +10,4 @@ proc-macro2 = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
+regex = "1.10"

--- a/packages/rules/src/lib.rs
+++ b/packages/rules/src/lib.rs
@@ -1,5 +1,7 @@
-pub mod unused_state_variables;
 pub mod rule_engine;
+pub mod unused_state_variables;
+pub mod vyper;
 
-pub use unused_state_variables::*;
 pub use rule_engine::*;
+pub use unused_state_variables::*;
+pub use vyper::*;

--- a/packages/rules/src/vyper/mod.rs
+++ b/packages/rules/src/vyper/mod.rs
@@ -1,0 +1,5 @@
+pub mod parser;
+pub mod redundant_external;
+
+pub use parser::*;
+pub use redundant_external::*;

--- a/packages/rules/src/vyper/parser.rs
+++ b/packages/rules/src/vyper/parser.rs
@@ -1,0 +1,189 @@
+use regex::Regex;
+use std::collections::HashSet;
+
+/// Represents a parsed Vyper function with its decorators and metadata
+#[derive(Debug, Clone)]
+pub struct VyperFunction {
+    pub name: String,
+    pub decorators: Vec<String>,
+    pub line_number: usize,
+    pub column_number: usize,
+}
+
+/// Represents a function call within the contract
+#[derive(Debug, Clone)]
+pub struct VyperFunctionCall {
+    pub function_name: String,
+    pub is_self_call: bool,
+    pub line_number: usize,
+}
+
+/// Parsed Vyper contract representation
+#[derive(Debug, Clone)]
+pub struct VyperContract {
+    pub functions: Vec<VyperFunction>,
+    pub function_calls: Vec<VyperFunctionCall>,
+}
+
+impl VyperContract {
+    /// Parse Vyper source code and extract function definitions with decorators
+    pub fn parse(source: &str) -> Result<Self, String> {
+        let mut functions = Vec::new();
+        let mut function_calls = Vec::new();
+        let mut current_decorators: Vec<String> = Vec::new();
+        let mut decorator_start_line: Option<usize> = None;
+
+        // Regex patterns for Vyper parsing
+        let decorator_pattern = Regex::new(r"^@(\w+)").map_err(|e| e.to_string())?;
+        let function_pattern = Regex::new(r"^def\s+(\w+)\s*\(").map_err(|e| e.to_string())?;
+        let self_call_pattern = Regex::new(r"self\.(\w+)\s*\(").map_err(|e| e.to_string())?;
+
+        for (line_idx, line) in source.lines().enumerate() {
+            let line_number = line_idx + 1;
+            let trimmed = line.trim();
+
+            // Check for decorator
+            if let Some(captures) = decorator_pattern.captures(trimmed) {
+                if let Some(decorator_name) = captures.get(1) {
+                    if current_decorators.is_empty() {
+                        decorator_start_line = Some(line_number);
+                    }
+                    current_decorators.push(decorator_name.as_str().to_string());
+                }
+            }
+            // Check for function definition
+            else if let Some(captures) = function_pattern.captures(trimmed) {
+                if let Some(func_name) = captures.get(1) {
+                    let func_line = decorator_start_line.unwrap_or(line_number);
+                    functions.push(VyperFunction {
+                        name: func_name.as_str().to_string(),
+                        decorators: current_decorators.clone(),
+                        line_number: func_line,
+                        column_number: 1,
+                    });
+                    current_decorators.clear();
+                    decorator_start_line = None;
+                }
+            }
+            // Check for non-decorator, non-function lines (reset decorators if we hit something else)
+            else if !trimmed.is_empty() && !trimmed.starts_with('#') {
+                // If we encounter a non-empty, non-comment line that's not a decorator or function,
+                // and we have pending decorators, they might be orphaned (edge case)
+                // For now, we keep collecting decorators until we hit a function
+            }
+
+            // Track self.function() calls for internal usage analysis
+            for captures in self_call_pattern.captures_iter(line) {
+                if let Some(func_name) = captures.get(1) {
+                    function_calls.push(VyperFunctionCall {
+                        function_name: func_name.as_str().to_string(),
+                        is_self_call: true,
+                        line_number,
+                    });
+                }
+            }
+        }
+
+        Ok(VyperContract {
+            functions,
+            function_calls,
+        })
+    }
+
+    /// Get all functions that are only called internally (via self.)
+    pub fn get_internally_called_functions(&self) -> HashSet<String> {
+        self.function_calls
+            .iter()
+            .filter(|call| call.is_self_call)
+            .map(|call| call.function_name.clone())
+            .collect()
+    }
+
+    /// Check if a function has a specific decorator
+    pub fn function_has_decorator(func: &VyperFunction, decorator: &str) -> bool {
+        func.decorators.iter().any(|d| d == decorator)
+    }
+
+    /// Check if function name suggests it should be internal (starts with _)
+    pub fn is_internal_naming_convention(func_name: &str) -> bool {
+        func_name.starts_with('_') && !func_name.starts_with("__")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_simple_function() {
+        let source = r#"
+@external
+def my_function():
+    pass
+"#;
+        let contract = VyperContract::parse(source).unwrap();
+        assert_eq!(contract.functions.len(), 1);
+        assert_eq!(contract.functions[0].name, "my_function");
+        assert_eq!(contract.functions[0].decorators, vec!["external"]);
+    }
+
+    #[test]
+    fn test_parse_internal_function() {
+        let source = r#"
+@internal
+def _helper():
+    pass
+"#;
+        let contract = VyperContract::parse(source).unwrap();
+        assert_eq!(contract.functions.len(), 1);
+        assert_eq!(contract.functions[0].name, "_helper");
+        assert_eq!(contract.functions[0].decorators, vec!["internal"]);
+    }
+
+    #[test]
+    fn test_parse_multiple_decorators() {
+        let source = r#"
+@external
+@view
+def get_value() -> uint256:
+    return self.value
+"#;
+        let contract = VyperContract::parse(source).unwrap();
+        assert_eq!(contract.functions.len(), 1);
+        assert_eq!(contract.functions[0].decorators, vec!["external", "view"]);
+    }
+
+    #[test]
+    fn test_detect_self_calls() {
+        let source = r#"
+@external
+def main():
+    self._helper()
+    self.another_function()
+
+@internal
+def _helper():
+    pass
+"#;
+        let contract = VyperContract::parse(source).unwrap();
+        assert_eq!(contract.function_calls.len(), 2);
+        assert!(contract
+            .get_internally_called_functions()
+            .contains("_helper"));
+        assert!(contract
+            .get_internally_called_functions()
+            .contains("another_function"));
+    }
+
+    #[test]
+    fn test_internal_naming_convention() {
+        assert!(VyperContract::is_internal_naming_convention("_helper"));
+        assert!(VyperContract::is_internal_naming_convention(
+            "_calculate_fee"
+        ));
+        assert!(!VyperContract::is_internal_naming_convention(
+            "public_function"
+        ));
+        assert!(!VyperContract::is_internal_naming_convention("__init__")); // Dunder methods excluded
+    }
+}

--- a/packages/rules/src/vyper/redundant_external.rs
+++ b/packages/rules/src/vyper/redundant_external.rs
@@ -1,0 +1,334 @@
+use crate::rule_engine::{RuleViolation, ViolationSeverity};
+use crate::vyper::parser::{VyperContract, VyperFunction};
+use std::collections::HashSet;
+
+/// Rule for detecting redundant @external decorators on internal Vyper functions
+///
+/// This rule identifies functions that are marked as @external but should be @internal:
+/// 1. Functions with _ prefix naming convention (indicates internal use)
+/// 2. Functions that are only called internally via self.function()
+pub struct RedundantExternalDecoratorRule;
+
+/// Vyper-specific rule trait for analyzing Vyper contracts
+pub trait VyperRule {
+    fn name(&self) -> &str;
+    fn description(&self) -> &str;
+    fn check(&self, contract: &VyperContract) -> Vec<RuleViolation>;
+}
+
+impl VyperRule for RedundantExternalDecoratorRule {
+    fn name(&self) -> &str {
+        "vyper-redundant-external"
+    }
+
+    fn description(&self) -> &str {
+        "Detects internal functions that are accidentally marked as @external, which leads to higher gas consumption and potential security gaps."
+    }
+
+    fn check(&self, contract: &VyperContract) -> Vec<RuleViolation> {
+        let mut violations = Vec::new();
+
+        // Get all functions that are called internally
+        let internally_called = contract.get_internally_called_functions();
+
+        // Get all function names that are defined with @external
+        let external_functions: HashSet<String> = contract
+            .functions
+            .iter()
+            .filter(|f| VyperContract::function_has_decorator(f, "external"))
+            .map(|f| f.name.clone())
+            .collect();
+
+        for func in &contract.functions {
+            // Check if function has @external decorator
+            if !VyperContract::function_has_decorator(func, "external") {
+                continue;
+            }
+
+            // Detection 1: Internal naming convention with @external
+            if VyperContract::is_internal_naming_convention(&func.name) {
+                violations.push(self.create_naming_violation(func));
+            }
+            // Detection 2: Function only called internally but marked @external
+            else if self.is_only_called_internally(
+                &func.name,
+                &internally_called,
+                &external_functions,
+            ) {
+                violations.push(self.create_internal_usage_violation(func));
+            }
+        }
+
+        violations
+    }
+}
+
+impl RedundantExternalDecoratorRule {
+    /// Create a violation for functions with internal naming convention but @external decorator
+    fn create_naming_violation(&self, func: &VyperFunction) -> RuleViolation {
+        RuleViolation {
+            rule_name: self.name().to_string(),
+            description: format!(
+                "Function '{}' is marked @external but uses internal naming convention (_prefix). \
+                This may expose internal logic unnecessarily and increase gas costs.",
+                func.name
+            ),
+            severity: ViolationSeverity::Warning,
+            line_number: func.line_number,
+            column_number: func.column_number,
+            variable_name: func.name.clone(),
+            suggestion: format!(
+                "Consider changing @external to @internal for function '{}'. \
+                Internal functions save gas by not generating external interface code and improve security by not exposing internal logic.",
+                func.name
+            ),
+        }
+    }
+
+    /// Create a violation for functions only called internally but marked @external
+    fn create_internal_usage_violation(&self, func: &VyperFunction) -> RuleViolation {
+        RuleViolation {
+            rule_name: self.name().to_string(),
+            description: format!(
+                "Function '{}' is marked @external but appears to only be called internally (via self.{}()). \
+                This wastes gas and may expose internal logic unnecessarily.",
+                func.name, func.name
+            ),
+            severity: ViolationSeverity::Warning,
+            line_number: func.line_number,
+            column_number: func.column_number,
+            variable_name: func.name.clone(),
+            suggestion: format!(
+                "Consider changing @external to @internal for function '{}' if it's not meant to be called externally. \
+                Internal functions are more gas-efficient and don't expose the function in the contract's ABI.",
+                func.name
+            ),
+        }
+    }
+
+    /// Check if a function is only called internally and not intended for external use
+    fn is_only_called_internally(
+        &self,
+        func_name: &str,
+        internally_called: &HashSet<String>,
+        _external_functions: &HashSet<String>,
+    ) -> bool {
+        // Function must be called internally at least once
+        if !internally_called.contains(func_name) {
+            return false;
+        }
+
+        // Skip common entry points that are legitimately external
+        let common_external = ["__init__", "__default__", "initialize", "setup"];
+        if common_external.contains(&func_name) {
+            return false;
+        }
+
+        // If a function is called internally AND marked external, it might be redundant
+        // This is a heuristic - the function might still need external access
+        // We only flag it if it looks like a helper function
+        self.looks_like_helper_function(func_name)
+    }
+
+    /// Heuristic to determine if a function looks like a helper/utility function
+    fn looks_like_helper_function(&self, func_name: &str) -> bool {
+        let helper_patterns = [
+            "helper",
+            "util",
+            "compute",
+            "calculate",
+            "validate",
+            "check",
+            "get_",
+            "set_",
+            "update_",
+            "process_",
+            "handle_",
+        ];
+
+        let lower_name = func_name.to_lowercase();
+        helper_patterns
+            .iter()
+            .any(|pattern| lower_name.contains(pattern))
+    }
+}
+
+/// Vyper rule engine for running Vyper-specific rules
+pub struct VyperRuleEngine {
+    rules: Vec<Box<dyn VyperRule>>,
+}
+
+impl VyperRuleEngine {
+    pub fn new() -> Self {
+        Self { rules: Vec::new() }
+    }
+
+    pub fn with_default_rules() -> Self {
+        let mut engine = Self::new();
+        engine.add_rule(Box::new(RedundantExternalDecoratorRule));
+        engine
+    }
+
+    pub fn add_rule(&mut self, rule: Box<dyn VyperRule>) {
+        self.rules.push(rule);
+    }
+
+    pub fn analyze(&self, source: &str) -> Result<Vec<RuleViolation>, String> {
+        let contract = VyperContract::parse(source)?;
+
+        let mut violations = Vec::new();
+        for rule in &self.rules {
+            violations.extend(rule.check(&contract));
+        }
+
+        Ok(violations)
+    }
+}
+
+impl Default for VyperRuleEngine {
+    fn default() -> Self {
+        Self::with_default_rules()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_external_on_internal_naming() {
+        let source = r#"
+# @version ^0.3.0
+
+@external
+def _internal_helper() -> uint256:
+    return 42
+
+@external
+def public_function() -> uint256:
+    return self._internal_helper()
+"#;
+        let engine = VyperRuleEngine::with_default_rules();
+        let violations = engine.analyze(source).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].variable_name, "_internal_helper");
+        assert!(violations[0]
+            .description
+            .contains("internal naming convention"));
+    }
+
+    #[test]
+    fn test_no_violation_on_proper_internal() {
+        let source = r#"
+# @version ^0.3.0
+
+@internal
+def _helper() -> uint256:
+    return 42
+
+@external
+def public_function() -> uint256:
+    return self._helper()
+"#;
+        let engine = VyperRuleEngine::with_default_rules();
+        let violations = engine.analyze(source).unwrap();
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_no_violation_on_legitimate_external() {
+        let source = r#"
+# @version ^0.3.0
+
+@external
+def deposit(amount: uint256):
+    pass
+
+@external
+def withdraw(amount: uint256):
+    pass
+
+@external
+@view
+def balance() -> uint256:
+    return 0
+"#;
+        let engine = VyperRuleEngine::with_default_rules();
+        let violations = engine.analyze(source).unwrap();
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_detect_helper_function_called_internally() {
+        let source = r#"
+# @version ^0.3.0
+
+@external
+def calculate_fee(amount: uint256) -> uint256:
+    return amount * 3 / 1000
+
+@external
+def process_payment(amount: uint256):
+    fee: uint256 = self.calculate_fee(amount)
+"#;
+        let engine = VyperRuleEngine::with_default_rules();
+        let violations = engine.analyze(source).unwrap();
+
+        // calculate_fee is called internally and looks like a helper
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].variable_name, "calculate_fee");
+    }
+
+    #[test]
+    fn test_multiple_violations() {
+        let source = r#"
+# @version ^0.3.0
+
+@external
+def _private_logic():
+    pass
+
+@external
+def _another_internal():
+    pass
+
+@external
+def public_api():
+    self._private_logic()
+    self._another_internal()
+"#;
+        let engine = VyperRuleEngine::with_default_rules();
+        let violations = engine.analyze(source).unwrap();
+
+        assert_eq!(violations.len(), 2);
+        let names: Vec<&str> = violations
+            .iter()
+            .map(|v| v.variable_name.as_str())
+            .collect();
+        assert!(names.contains(&"_private_logic"));
+        assert!(names.contains(&"_another_internal"));
+    }
+
+    #[test]
+    fn test_dunder_methods_not_flagged() {
+        let source = r#"
+# @version ^0.3.0
+
+@external
+def __init__():
+    pass
+
+@external
+def __default__():
+    pass
+"#;
+        let engine = VyperRuleEngine::with_default_rules();
+        let violations = engine.analyze(source).unwrap();
+
+        // Dunder methods should not be flagged
+        assert_eq!(violations.len(), 0);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #4

This PR adds Vyper language support to GasGuard with a detector that identifies internal functions accidentally marked as `@external`, which can lead to higher gas consumption and potential security gaps.

## Changes

- **New Vyper module** in `packages/rules/src/vyper/`
  - `parser.rs`: Regex-based Vyper parser for function definitions and decorators
  - `redundant_external.rs`: Main detector rule implementation with `VyperRuleEngine`
  - `mod.rs`: Module exports

- **Scanner updates** in `libs/engine/src/scanner.rs`
  - Added `.vy` file detection
  - Integrated `VyperRuleEngine` for Vyper file analysis

- **Example file** `examples/redundant_external.vy`
  - Demonstrates violations and correct patterns

## Detection Logic

The detector identifies:

1. **Internal naming convention violations**: Functions with `_` prefix (e.g., `_calculate_fee`) that are marked `@external` - these should typically be `@internal`

2. **Internal-only usage**: Functions that are only called via `self.function_name()` but marked `@external`

## Example Output

```
$ cargo run -- scan examples/redundant_external.vy

🔍 Scanning file: "examples/redundant_external.vy"
⚠️  2 Warnings:
  [WARNING]
  📍 Line 20: _calculate_fee
  📝 Function '_calculate_fee' is marked @external but uses internal naming convention (_prefix).
  💡 Consider changing @external to @internal for function '_calculate_fee'.
```

## Testing

- 11 unit tests for parser and detector - all passing
- Tests cover:
  - Internal naming convention detection
  - Internal-only usage detection
  - No false positives on legitimate external functions
  - Dunder methods (`__init__`, `__default__`) are not flagged
  - Multiple violations handling

## Technical Notes

- Uses regex-based parsing for simplicity and reliability
- Follows existing GasGuard architecture patterns
- Integrates with existing CLI and scanning infrastructure