### PR TITLE
feat: hot reload for rule development (#266)

### DIFF
--- a/src/analysis/dev/hot-reload.ts
+++ b/src/analysis/dev/hot-reload.ts
@@ -1,0 +1,158 @@
+/**
+ * Hot Reload for Rule Development (#266).
+ *
+ * Wires the existing `ScanWatcher` (file-system event source) to the existing
+ * `DynamicRuleLoader` (rule cache + dynamic import), giving plugin authors a
+ * tight edit-save-rerun loop without restarting the analysis process.
+ *
+ * On a watched plugin file change:
+ *   1. Resolve which rule id(s) the file belongs to (from `RuleSource` map).
+ *   2. Invalidate every cached version of those rules.
+ *   3. Optionally re-load the rule immediately so the next analysis run hits
+ *      a warm cache.
+ *   4. Emit a `ruleReloaded` event so the running engine can pick up the new
+ *      definition.
+ *
+ * Unwatched on shutdown so `Ctrl+C` exits cleanly.
+ */
+
+import { EventEmitter } from 'events';
+import path from 'path';
+
+import { ScanWatcher } from '../watch/watcher';
+import { DynamicRuleLoader } from '../loader/dynamic-loader';
+import type { RuleConfiguration } from '../../config/config.types';
+
+/**
+ * Maps a source file path → rule configuration. The hot-reloader uses this to
+ * translate a file-change event into the rule id(s) it should invalidate.
+ *
+ * Callers populate this map either explicitly (manual registration) or by
+ * scanning plugin manifests at startup.
+ */
+export type RuleSource = Map<string, RuleConfiguration>;
+
+export interface HotReloadOptions {
+  /** Absolute path to the directory containing plugin source files. */
+  pluginsDir: string;
+  /** Initial mapping from plugin file path → rule config. */
+  ruleSources?: RuleSource;
+  /** Debounce multi-write storms (e.g. atomic save). Default: 150ms. */
+  debounceMs?: number;
+  /** Eagerly re-load the rule after invalidation so the next call is warm. Default: true. */
+  eagerReload?: boolean;
+  /** Predicate to skip files. Default: ignore `node_modules`, dotfiles, and `dist/`. */
+  ignored?: (filePath: string) => boolean;
+}
+
+export interface RuleReloadedEvent {
+  ruleId: string;
+  filePath: string;
+  durationMs: number;
+}
+
+export interface RuleSourceMissingEvent {
+  filePath: string;
+}
+
+function defaultIgnored(filePath: string): boolean {
+  const segments = filePath.split(path.sep);
+  return (
+    segments.includes('node_modules') ||
+    segments.includes('dist') ||
+    segments.some((s) => s.startsWith('.'))
+  );
+}
+
+/**
+ * Watches a plugin directory and refreshes the rule cache when files change.
+ *
+ * Events emitted:
+ *   - `ruleReloaded` ({@link RuleReloadedEvent})
+ *   - `ruleSourceMissing` ({@link RuleSourceMissingEvent}) — file changed but no
+ *     rule config registered for it; usually a missed `register()` call.
+ *   - `error` (Error)
+ */
+export class RuleHotReloader extends EventEmitter {
+  private readonly watcher: ScanWatcher;
+  private readonly loader: DynamicRuleLoader;
+  private readonly sources: RuleSource;
+  private readonly options: Required<Omit<HotReloadOptions, 'ruleSources'>>;
+  private active = false;
+
+  constructor(loader: DynamicRuleLoader, options: HotReloadOptions) {
+    super();
+    this.loader = loader;
+    this.sources = options.ruleSources ?? new Map();
+    this.options = {
+      pluginsDir: options.pluginsDir,
+      debounceMs: options.debounceMs ?? 150,
+      eagerReload: options.eagerReload ?? true,
+      ignored: options.ignored ?? defaultIgnored,
+    };
+    this.watcher = new ScanWatcher(options.pluginsDir, {
+      debounceMs: this.options.debounceMs,
+      ignored: this.options.ignored,
+    });
+  }
+
+  /** Register (or replace) the rule config a given plugin file produces. */
+  register(filePath: string, config: RuleConfiguration): void {
+    this.sources.set(path.resolve(filePath), config);
+  }
+
+  /** Drop a registered file from the source map. Returns true if it was present. */
+  unregister(filePath: string): boolean {
+    return this.sources.delete(path.resolve(filePath));
+  }
+
+  /** Number of files currently mapped to a rule config. */
+  size(): number {
+    return this.sources.size;
+  }
+
+  /** Begin watching. Idempotent. */
+  start(): void {
+    if (this.active) return;
+    this.active = true;
+    this.watcher.watch((filePath) => this.handleChange(filePath).catch((err) => this.emit('error', err)));
+  }
+
+  /** Stop watching and release file descriptors. Idempotent. */
+  stop(): void {
+    if (!this.active) return;
+    this.active = false;
+    this.watcher.stop();
+  }
+
+  private async handleChange(filePath: string): Promise<void> {
+    const resolved = path.resolve(filePath);
+    const config = this.sources.get(resolved);
+    if (!config) {
+      const event: RuleSourceMissingEvent = { filePath: resolved };
+      this.emit('ruleSourceMissing', event);
+      return;
+    }
+
+    const start = Date.now();
+    // Drop every cached version of this rule — a code change might
+    // semantically affect any version, and re-loading the active one alone is
+    // cheap.
+    this.loader.invalidateRulesById(config.id);
+
+    if (this.options.eagerReload) {
+      const reloaded = await this.loader.loadRule(config);
+      if (reloaded === null) {
+        this.emit('error', new Error(`Hot reload failed for rule ${config.id}`));
+        return;
+      }
+    }
+
+    const event: RuleReloadedEvent = {
+      ruleId: config.id,
+      filePath: resolved,
+      durationMs: Date.now() - start,
+    };
+    this.emit('ruleReloaded', event);
+  }
+}

--- a/src/analysis/dev/index.ts
+++ b/src/analysis/dev/index.ts
@@ -1,0 +1,7 @@
+export { RuleHotReloader } from './hot-reload';
+export type {
+  HotReloadOptions,
+  RuleSource,
+  RuleReloadedEvent,
+  RuleSourceMissingEvent,
+} from './hot-reload';

--- a/src/analysis/loader/dynamic-loader.ts
+++ b/src/analysis/loader/dynamic-loader.ts
@@ -23,6 +23,24 @@ export class RuleCache {
     this.cache.set(`${id}@${version}`, module);
   }
 
+  /** Drop a single (id, version) entry. Returns true if it was cached. */
+  delete(id: string, version: string): boolean {
+    return this.cache.delete(`${id}@${version}`);
+  }
+
+  /** Drop every entry that matches the given rule id, ignoring version. */
+  deleteById(id: string): number {
+    let removed = 0;
+    const prefix = `${id}@`;
+    for (const key of this.cache.keys()) {
+      if (key.startsWith(prefix)) {
+        this.cache.delete(key);
+        removed += 1;
+      }
+    }
+    return removed;
+  }
+
   clear(): void {
     this.cache.clear();
   }
@@ -67,5 +85,27 @@ export class DynamicRuleLoader {
    */
   async preloadRules(configs: RuleConfiguration[]): Promise<void> {
     await Promise.all(configs.map(config => this.loadRule(config)));
+  }
+
+  /**
+   * Drop a specific (id, version) from the cache so the next `loadRule` call
+   * re-imports it. Returns true if the entry was present.
+   */
+  invalidateRule(id: string, version: string): boolean {
+    return this.cache.delete(id, version);
+  }
+
+  /** Drop every cached version of `id`. Used when a plugin file changes on disk. */
+  invalidateRulesById(id: string): number {
+    return this.cache.deleteById(id);
+  }
+
+  /**
+   * Force a fresh load of the given rule by invalidating any cached entry
+   * first. Convenience wrapper used by the hot-reload pipeline.
+   */
+  async reloadRule(config: RuleConfiguration): Promise<RuleModule | null> {
+    this.cache.delete(config.id, config.version);
+    return this.loadRule(config);
   }
 }


### PR DESCRIPTION
## Summary

Closes #266 — Adds `RuleHotReloader` at `src/analysis/dev/` that wires the existing `ScanWatcher` (file-system event source) to the existing `DynamicRuleLoader` (rule cache + dynamic import), giving plugin authors a tight edit-save-rerun loop without restarting the analysis process.

### What's new

- `src/analysis/dev/hot-reload.ts` — `RuleHotReloader` class. Watches a plugins directory, maps changed files → `RuleConfiguration` via a registered source map, invalidates the cache for the affected rule id, and optionally eagerly re-loads it so the next analysis run hits a warm cache. Emits `ruleReloaded`, `ruleSourceMissing`, and `error` events for the engine to react to.
- `src/analysis/dev/index.ts` — barrel export.

### What changed (additive only)

- `src/analysis/loader/dynamic-loader.ts`
  - `RuleCache.delete(id, version)` and `RuleCache.deleteById(id)` — drop entries without nuking the whole cache.
  - `DynamicRuleLoader.invalidateRule(id, version)`, `invalidateRulesById(id)`, and `reloadRule(config)` — public surface area for force-reloads.
  - No existing methods or signatures changed.

### Why this approach

Two pieces already existed:
- `ScanWatcher` (in `src/analysis/watch/watcher.ts`) — debounced file watcher.
- `DynamicRuleLoader` (in `src/analysis/loader/dynamic-loader.ts`) — rule cache + on-demand loader.

Hot reload is just the wiring between them. Putting that wiring in a new `src/analysis/dev/` module keeps it cleanly separable from prod code paths — the engine can opt-in by instantiating `RuleHotReloader` only when running in dev mode.

## Test plan

- [ ] Register a plugin file → save a change → `ruleReloaded` fires with the correct `ruleId`, `filePath`, and `durationMs`
- [ ] Change a file with no registered rule → `ruleSourceMissing` fires (no crash)
- [ ] `stop()` releases all file watchers; calling `stop()` twice is a no-op
- [ ] After invalidation, next `loader.loadRule()` actually re-imports rather than returning the stale cached entry
- [ ] `eagerReload: false` invalidates but defers re-load until the next `loadRule` call