### PR TITLE
feat(pre-commit): add husky pre-commit scan for staged files (issue#257)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+# Run GasGuard staged-file scan
+node scripts/pre-commit-scan.js

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "gasguard-monorepo",
   "private": true,
   "scripts": {
+    "prepare": "husky install",
     "build": "tsc -b",
     "build:engine": "tsc -p libs/engine/tsconfig.json",
     "build:api": "nest build",
@@ -28,6 +29,7 @@
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
+    "husky": "^8.0.0",
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",

--- a/scripts/pre-commit-scan.js
+++ b/scripts/pre-commit-scan.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+const { execSync, spawnSync } = require('child_process');
+const path = require('path');
+
+function getStagedFiles() {
+  try {
+    const out = execSync('git diff --cached --name-only --diff-filter=ACM', { encoding: 'utf8' });
+    return out.split(/\r?\n/).map(s => s.trim()).filter(Boolean);
+  } catch (err) {
+    console.error('Failed to get staged files:', err.message);
+    process.exit(1);
+  }
+}
+
+function filterScannable(files) {
+  const exts = ['.sol', '.vy', '.rs'];
+  return files.filter(f => exts.includes(path.extname(f)));
+}
+
+function runScanOnFile(file) {
+  console.log(`Running GasGuard scan on staged file: ${file}`);
+
+  // Execute the monorepo CLI using ts-node to run the TypeScript source directly.
+  // This avoids requiring a pre-built CLI binary during development.
+  const runner = 'node';
+  const args = ['-r', 'ts-node/register', 'packages/cli/src/index.ts', 'scan', file, '--no-summary', '--format', 'text'];
+
+  const res = spawnSync(runner, args, { stdio: 'inherit' });
+  if (res.error) {
+    console.error('Failed to start scan process:', res.error);
+    return res.status || 1;
+  }
+  return res.status;
+}
+
+async function main() {
+  const staged = getStagedFiles();
+  const targets = filterScannable(staged);
+
+  if (targets.length === 0) {
+    console.log('No scannable staged files found. Skipping GasGuard pre-commit scan.');
+    process.exit(0);
+  }
+
+  let failed = false;
+  for (const f of targets) {
+    const code = runScanOnFile(f);
+    if (code !== 0) {
+      failed = true;
+      console.error(`GasGuard scan failed for ${f} (exit ${code})`);
+      break;
+    }
+  }
+
+  if (failed) process.exit(1);
+  console.log('GasGuard pre-commit scan passed.');
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
**Summary**
- Adds a committed Husky pre-commit hook that runs GasGuard scans on staged smart-contract files so issues are detected before commits.

**What changed**
- **Files added:** pre-commit-scan.js — staged-file scanner that filters `.sol`, `.vy`, `.rs` and invokes the CLI for each file. See pre-commit-scan.js.
- **Files added:** pre-commit — committed Husky hook that runs the staged-file scanner. See pre-commit.
- **Files modified:** package.json — adds `"prepare": "husky install"` script and `husky` devDependency so hooks are installed on `pnpm install`. See package.json.

**Why**
- Prevent gas/regression issues from being committed by scanning staged contract files at commit time.
- Minimal, developer-local protection that does not change runtime behavior or CI policies.

**Testing performed**
- Ran `node scripts/pre-commit-scan.js` locally; it exits cleanly when no staged scannable files exist.
- Created branch `feature/issue-257-husky-precommit`, committed only the three relevant files and pushed the branch.
- Suggested local test flow:
  - Install deps (sets up Husky):
    - `pnpm install`
  - Make executable (if required):
    - `chmod +x .husky/pre-commit`
  - Stage a scannable file and commit:
    - `git add path/to/contract.sol`
    - `git commit -m "test pre-commit hook"`

**Risks considered**
- Hook invokes the TypeScript CLI via `ts-node/register`; dev dependencies must be installed for the hook to run. This is documented in the test steps.
- Running one scan per staged file may be slower with many staged files. This is intentionally minimal; can be optimized to batch-scan if desired.

**Edge cases handled**
- If there are no staged scannable files, the hook exits successfully and allows the commit.
- If a scan fails for a staged file, the commit is blocked (exit code 1), preventing bad commits.

**Remediation / follow-ups (optional)**
- Batch staged files into a single scanner invocation for performance.
- Add a GitHub Action to run the same scan on pushes/PRs for server-side enforcement.
- Replace `ts-node` invocation with a built `gasguard` binary for environments that prefer not to rely on devDependencies.

**Branch**
- `feature/issue-257-husky-precommit`

Closes #257

---