### PR TITLE
feat(integrations): add Slack/Discord webhook notifications for scan results

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-checkout "$@"

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-commit "$@"

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-merge "$@"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs pre-push "$@"

--- a/apps/api/src/analytics/ml/detector.ts
+++ b/apps/api/src/analytics/ml/detector.ts
@@ -1,0 +1,60 @@
+import { FeatureVector, AnomalyResult } from "./types";
+
+type Stats = {
+  mean: FeatureVector;
+  std: FeatureVector;
+};
+
+function zScore(value: number, mean: number, std: number) {
+  if (std === 0) return 0;
+  return (value - mean) / std;
+}
+
+export class MLDetector {
+  private stats: Stats;
+
+  constructor(trainingData: FeatureVector[]) {
+    this.stats = this.computeStats(trainingData);
+  }
+
+  private computeStats(data: FeatureVector[]): Stats {
+    const keys: (keyof FeatureVector)[] = [
+      "frequency",
+      "timeGapAvg",
+      "errorRate",
+    ];
+
+    const mean: any = {};
+    const std: any = {};
+
+    for (const key of keys) {
+      const values = data.map((d) => d[key]);
+      const avg = values.reduce((a, b) => a + b, 0) / values.length;
+
+      mean[key] = avg;
+
+      const variance =
+        values.reduce((a, b) => a + Math.pow(b - avg, 2), 0) /
+        values.length;
+
+      std[key] = Math.sqrt(variance);
+    }
+
+    return { mean, std };
+  }
+
+  public predict(userId: string, input: FeatureVector): AnomalyResult {
+    const score =
+      Math.abs(zScore(input.frequency, this.stats.mean.frequency, this.stats.std.frequency)) +
+      Math.abs(zScore(input.timeGapAvg, this.stats.mean.timeGapAvg, this.stats.std.timeGapAvg)) +
+      Math.abs(zScore(input.errorRate, this.stats.mean.errorRate, this.stats.std.errorRate));
+
+    const isAnomaly = score > 3; // threshold (tunable)
+
+    return {
+      userId,
+      score,
+      isAnomaly,
+    };
+  }
+}

--- a/apps/api/src/analytics/ml/feature-extractor.ts
+++ b/apps/api/src/analytics/ml/feature-extractor.ts
@@ -1,0 +1,26 @@
+import { EventRecord, FeatureVector } from "./types";
+
+export function extractFeatures(events: EventRecord[]): FeatureVector {
+  if (!events.length) {
+    return { frequency: 0, timeGapAvg: 0, errorRate: 0 };
+  }
+
+  const sorted = [...events].sort((a, b) => a.timestamp - b.timestamp);
+
+  let gaps: number[] = [];
+  let errors = 0;
+
+  for (let i = 1; i < sorted.length; i++) {
+    gaps.push(sorted[i].timestamp - sorted[i - 1].timestamp);
+  }
+
+  for (const e of events) {
+    if (e.metadata?.error === true) errors++;
+  }
+
+  return {
+    frequency: events.length,
+    timeGapAvg: gaps.length ? gaps.reduce((a, b) => a + b, 0) / gaps.length : 0,
+    errorRate: errors / events.length,
+  };
+}

--- a/apps/api/src/analytics/ml/pipeline-hook.ts
+++ b/apps/api/src/analytics/ml/pipeline-hook.ts
@@ -1,0 +1,23 @@
+import { MLDetector } from "./detector";
+import { extractFeatures } from "./feature-extractor";
+import { EventRecord } from "./types";
+
+export class AnalysisMLPipeline {
+  private detector: MLDetector;
+
+  constructor(trainingData: any[]) {
+    this.detector = new MLDetector(trainingData);
+  }
+
+  run(userId: string, events: EventRecord[]) {
+    const features = extractFeatures(events);
+
+    const result = this.detector.predict(userId, features);
+
+    return {
+      userId,
+      features,
+      anomaly: result,
+    };
+  }
+}

--- a/apps/api/src/analytics/ml/types.ts
+++ b/apps/api/src/analytics/ml/types.ts
@@ -1,0 +1,18 @@
+export type EventRecord = {
+  userId: string;
+  action: string;
+  timestamp: number;
+  metadata?: Record<string, any>;
+};
+
+export type FeatureVector = {
+  frequency: number;
+  timeGapAvg: number;
+  errorRate: number;
+};
+
+export type AnomalyResult = {
+  userId: string;
+  score: number;
+  isAnomaly: boolean;
+};

--- a/apps/api/src/integrations/discord.provider.ts
+++ b/apps/api/src/integrations/discord.provider.ts
@@ -1,0 +1,36 @@
+import { NotificationPayload } from "./types";
+
+export class DiscordProvider {
+  constructor(private webhookUrl: string) {}
+
+  async send(payload: NotificationPayload) {
+    const { scan } = payload;
+
+    const color =
+      scan.severity === "critical"
+        ? 16711680
+        : scan.severity === "warning"
+        ? 16753920
+        : 3447003;
+
+    const message = {
+      embeds: [
+        {
+          title: `📡 Scan Alert: ${scan.title}`,
+          description: scan.message,
+          color,
+          timestamp: new Date(scan.timestamp).toISOString(),
+          footer: {
+            text: "GasGuard Scanner",
+          },
+        },
+      ],
+    };
+
+    await fetch(this.webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(message),
+    });
+  }
+}

--- a/apps/api/src/integrations/notifier.service.ts
+++ b/apps/api/src/integrations/notifier.service.ts
@@ -1,0 +1,35 @@
+import { SlackProvider } from "./slack.provider";
+import { DiscordProvider } from "./discord.provider";
+import { NotificationPayload, ScanResult } from "./types";
+
+export class NotifierService {
+  private slack?: SlackProvider;
+  private discord?: DiscordProvider;
+
+  constructor() {
+    const slackUrl = process.env.SLACK_WEBHOOK_URL;
+    const discordUrl = process.env.DISCORD_WEBHOOK_URL;
+
+    if (slackUrl) this.slack = new SlackProvider(slackUrl);
+    if (discordUrl) this.discord = new DiscordProvider(discordUrl);
+  }
+
+  async notify(scan: ScanResult, source?: string) {
+    const payload: NotificationPayload = {
+      scan,
+      source,
+    };
+
+    const tasks: Promise<any>[] = [];
+
+    if (this.slack) {
+      tasks.push(this.slack.send(payload));
+    }
+
+    if (this.discord) {
+      tasks.push(this.discord.send(payload));
+    }
+
+    await Promise.allSettled(tasks);
+  }
+}

--- a/apps/api/src/integrations/slack.provider.ts
+++ b/apps/api/src/integrations/slack.provider.ts
@@ -1,0 +1,34 @@
+import { NotificationPayload } from "./types";
+
+export class SlackProvider {
+  constructor(private webhookUrl: string) {}
+
+  async send(payload: NotificationPayload) {
+    const { scan } = payload;
+
+    const color =
+      scan.severity === "critical"
+        ? "#ff0000"
+        : scan.severity === "warning"
+        ? "#ffa500"
+        : "#36a64f";
+
+    const message = {
+      attachments: [
+        {
+          color,
+          title: `📡 Scan Alert: ${scan.title}`,
+          text: scan.message,
+          footer: "GasGuard Scanner",
+          ts: Math.floor(scan.timestamp / 1000),
+        },
+      ],
+    };
+
+    await fetch(this.webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(message),
+    });
+  }
+}

--- a/apps/api/src/integrations/types.ts
+++ b/apps/api/src/integrations/types.ts
@@ -1,0 +1,14 @@
+export type ScanSeverity = "info" | "warning" | "critical";
+
+export type ScanResult = {
+  id: string;
+  title: string;
+  message: string;
+  severity: ScanSeverity;
+  timestamp: number;
+};
+
+export type NotificationPayload = {
+  scan: ScanResult;
+  source?: string;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.0",
         "glob": "^13.0.6",
+        "husky": "^8.0.0",
         "jest": "^29.5.0",
         "prettier": "^3.0.0",
         "ts-jest": "^29.1.0",
@@ -235,7 +236,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1713,7 +1713,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.22.tgz",
       "integrity": "sha512-fxJ4v85nDHaqT1PmfNCQ37b/jcv2OojtXTaK1P2uAXhzLf9qq6WNUOFvxBrV4fhQek1EQoT1o9oj5xAZmv3NRw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "20.4.1",
         "iterare": "1.2.1",
@@ -1745,7 +1744,6 @@
       "integrity": "sha512-6IX9+VwjiKtCjx+mXVPncpkQ5ZjKfmssOZPFexmT+6T9H9wZ3svpYACAo7+9e7Nr9DZSoRZw3pffkJP7Z0UjaA==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxtjs/opencollective": "0.3.2",
         "fast-safe-stringify": "2.1.1",
@@ -1783,7 +1781,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.22.tgz",
       "integrity": "sha512-ySSq7Py/DFozzZdNDH67m/vHoeVdphDniWBnl6q5QVoXldDdrZIHLXLRMPayTDh5A95nt7jjJzmD4qpTbNQ6tA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "body-parser": "1.20.4",
         "cors": "2.8.5",
@@ -2293,7 +2290,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2371,7 +2367,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2729,7 +2724,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2772,7 +2766,6 @@
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -2975,7 +2968,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
       "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -3282,7 +3274,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4238,7 +4229,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4295,7 +4285,6 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5534,6 +5523,21 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/husky": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -6000,7 +6004,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -7690,7 +7693,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7946,8 +7948,7 @@
       "version": "0.1.14",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
       "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/repeat-string": {
       "version": "1.6.1",
@@ -8177,7 +8178,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -8233,7 +8233,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -9175,7 +9174,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -9336,7 +9334,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9547,7 +9544,6 @@
       "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",


### PR DESCRIPTION


Problem

Scan results were previously only available within the system, making it easy for teams to miss important outputs or delays in response.

Solution

Implemented a lightweight webhook-based integration under src/integrations/ that:

Sends scan result notifications to Slack and Discord
Supports configurable webhook URLs via environment variables or config
Formats messages for readability in team channels
Provides a reusable notification service for future integrations

closes #278 