### PR TITLE
Feat/timestamp

### DIFF
--- a/libs/engine/analyzers/solidity-analyzer.ts
+++ b/libs/engine/analyzers/solidity-analyzer.ts
@@ -153,6 +153,16 @@ export class SolidityAnalyzer extends BaseAnalyzer implements Analyzer {
       documentationUrl: 'https://docs.gasguard.dev/rules/sol-013',
     },
     {
+      id: 'sol-014',
+      name: 'Insecure tx.origin Authentication',
+      description: 'Detects tx.origin usage in authentication or authorization checks and suggests using msg.sender instead.',
+      severity: Severity.HIGH,
+      category: 'security',
+      enabled: true,
+      tags: ['security', 'authentication', 'tx-origin', 'msg-sender'],
+      documentationUrl: 'https://docs.gasguard.dev/rules/sol-014',
+    },
+    {
       id: 'sol-012',
       name: 'Missing Event Emission',
       description: 'Detects state-changing functions that do not emit events',
@@ -343,6 +353,26 @@ export class SolidityAnalyzer extends BaseAnalyzer implements Analyzer {
             description: 'Avoid using block.timestamp or now for critical control flow. Use a secure timelock, on-chain delay based on block.number, or an oracle-backed time source.',
             codeSnippet: 'require(block.timestamp >= unlockTime, "Too early"); // avoid relying on timestamp for security-critical decisions',
             documentationUrl: 'https://docs.gasguard.dev/rules/sol-013',
+          },
+        })));
+      }
+
+      // Rule: sol-014 - Insecure tx.origin Authentication
+      if (this.isRuleEnabled('sol-014', config)) {
+        const txOriginFindings = this.detectTxOriginUsage(code);
+        findings.push(...txOriginFindings.map(location => ({
+          ruleId: 'sol-014',
+          message: location.message,
+          severity: this.getRuleSeverity('sol-014', config),
+          location: {
+            file: filePath,
+            startLine: location.startLine,
+            endLine: location.endLine,
+          },
+          suggestedFix: {
+            description: 'Use msg.sender for authentication and authorization checks instead of tx.origin to prevent phishing and contract-based attacks.',
+            codeSnippet: 'require(msg.sender == owner, "Unauthorized");',
+            documentationUrl: 'https://docs.gasguard.dev/rules/sol-014',
           },
         })));
       }
@@ -650,7 +680,7 @@ export class SolidityAnalyzer extends BaseAnalyzer implements Analyzer {
     const eventEmissionPattern = /\bemit\b/;
 
     for (let i = 0; i < lines.length; i++) {
-      let line = lines[i];
+      const line = lines[i];
       const trimmed = line.trim();
 
       if (trimmed.startsWith('/*') || trimmed.startsWith('/**')) {
@@ -681,6 +711,46 @@ export class SolidityAnalyzer extends BaseAnalyzer implements Analyzer {
         message:
           'Unsafe reliance on block.timestamp/now detected. Block timestamps are manipulable by miners, so avoid using them for critical control flow.',
       });
+    }
+
+    return findings;
+  }
+
+  private detectTxOriginUsage(
+    code: string,
+  ): Array<{ startLine: number; endLine: number; message: string }> {
+    const findings: Array<{ startLine: number; endLine: number; message: string }> = [];
+    const lines = code.split('\n');
+    let inBlockComment = false;
+
+    const txOriginPattern = /\btx\.origin\b/;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const trimmed = line.trim();
+
+      if (trimmed.startsWith('/*') || trimmed.startsWith('/**')) {
+        inBlockComment = true;
+      }
+      if (inBlockComment) {
+        if (trimmed.includes('*/')) {
+          inBlockComment = false;
+        }
+        continue;
+      }
+
+      if (trimmed.startsWith('//')) {
+        continue;
+      }
+
+      if (txOriginPattern.test(line)) {
+        findings.push({
+          startLine: i + 1,
+          endLine: i + 1,
+          message:
+            'Insecure tx.origin authentication detected. Use msg.sender instead of tx.origin for authorization checks.',
+        });
+      }
     }
 
     return findings;

--- a/libs/engine/analyzers/solidity-analyzer.ts
+++ b/libs/engine/analyzers/solidity-analyzer.ts
@@ -143,6 +143,16 @@ export class SolidityAnalyzer extends BaseAnalyzer implements Analyzer {
       },
     },
     {
+      id: 'sol-013',
+      name: 'Unsafe Timestamp Dependency',
+      description: 'Detects use of block.timestamp or now in control flow and warns when critical logic depends on manipulable timestamps.',
+      severity: Severity.HIGH,
+      category: 'security',
+      enabled: true,
+      tags: ['security', 'timestamp', 'blockchain', 'time-dependency'],
+      documentationUrl: 'https://docs.gasguard.dev/rules/sol-013',
+    },
+    {
       id: 'sol-012',
       name: 'Missing Event Emission',
       description: 'Detects state-changing functions that do not emit events',
@@ -313,6 +323,26 @@ export class SolidityAnalyzer extends BaseAnalyzer implements Analyzer {
             description: 'Use a timelock flow: schedule operation, enforce delay with block.timestamp checks, and execute after delay with role-based access control',
             codeSnippet: 'bytes32 opId = keccak256(data);\npendingOperations[opId] = block.timestamp + TIMELOCK_DELAY;\nemit OperationScheduled(opId, pendingOperations[opId]);\n\nrequire(block.timestamp >= pendingOperations[opId], "Timelock not expired");\nexecuteOperation(opId);\nemit OperationExecuted(opId);',
             documentationUrl: 'https://docs.gasguard.dev/rules/sol-009',
+          },
+        })));
+      }
+
+      // Rule: sol-013 - Unsafe Timestamp Dependency
+      if (this.isRuleEnabled('sol-013', config)) {
+        const timestampDependencies = this.detectTimestampDependencies(code);
+        findings.push(...timestampDependencies.map(location => ({
+          ruleId: 'sol-013',
+          message: location.message,
+          severity: this.getRuleSeverity('sol-013', config),
+          location: {
+            file: filePath,
+            startLine: location.startLine,
+            endLine: location.endLine,
+          },
+          suggestedFix: {
+            description: 'Avoid using block.timestamp or now for critical control flow. Use a secure timelock, on-chain delay based on block.number, or an oracle-backed time source.',
+            codeSnippet: 'require(block.timestamp >= unlockTime, "Too early"); // avoid relying on timestamp for security-critical decisions',
+            documentationUrl: 'https://docs.gasguard.dev/rules/sol-013',
           },
         })));
       }
@@ -605,6 +635,53 @@ export class SolidityAnalyzer extends BaseAnalyzer implements Analyzer {
         }
       }
     });
+
+    return findings;
+  }
+
+  private detectTimestampDependencies(
+    code: string,
+  ): Array<{ startLine: number; endLine: number; message: string }> {
+    const findings: Array<{ startLine: number; endLine: number; message: string }> = [];
+    const lines = code.split('\n');
+    let inBlockComment = false;
+
+    const timestampPattern = /\b(?:block\.timestamp|now)\b/;
+    const eventEmissionPattern = /\bemit\b/;
+
+    for (let i = 0; i < lines.length; i++) {
+      let line = lines[i];
+      const trimmed = line.trim();
+
+      if (trimmed.startsWith('/*') || trimmed.startsWith('/**')) {
+        inBlockComment = true;
+      }
+      if (inBlockComment) {
+        if (trimmed.includes('*/')) {
+          inBlockComment = false;
+        }
+        continue;
+      }
+
+      if (trimmed.startsWith('//')) {
+        continue;
+      }
+
+      if (!timestampPattern.test(line)) {
+        continue;
+      }
+
+      if (eventEmissionPattern.test(line)) {
+        continue;
+      }
+
+      findings.push({
+        startLine: i + 1,
+        endLine: i + 1,
+        message:
+          'Unsafe reliance on block.timestamp/now detected. Block timestamps are manipulable by miners, so avoid using them for critical control flow.',
+      });
+    }
 
     return findings;
   }

--- a/tests/rules/solidity-rules.spec.ts
+++ b/tests/rules/solidity-rules.spec.ts
@@ -148,6 +148,53 @@ contract LogTimestamp {
       const result = await analyzer.analyze(code, 'timestamp-log.sol');
       RuleAssertions.assertNotHasFinding(result.findings, 'sol-013');
     });
+
+    it('should detect insecure tx.origin authentication usage', async () => {
+      const code = `
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract OriginAuth {
+    address public owner;
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    function adminAction() external {
+        require(tx.origin == owner, "Not authorized");
+        // sensitive logic
+    }
+}
+`;
+
+      const result = await analyzer.analyze(code, 'origin-auth.sol');
+      RuleAssertions.assertHasFinding(result.findings, 'sol-014');
+      RuleAssertions.assertFindingMessage(result.findings, 'sol-014', 'tx.origin');
+    });
+
+    it('should not flag msg.sender authentication', async () => {
+      const code = `
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract SenderAuth {
+    address public owner;
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    function adminAction() external {
+        require(msg.sender == owner, "Not authorized");
+        // sensitive logic
+    }
+}
+`;
+
+      const result = await analyzer.analyze(code, 'sender-auth.sol');
+      RuleAssertions.assertNotHasFinding(result.findings, 'sol-014');
+    });
   });
 
   describe('Rule Assertions', () => {

--- a/tests/rules/solidity-rules.spec.ts
+++ b/tests/rules/solidity-rules.spec.ts
@@ -105,6 +105,51 @@ contract SecureBank is ReentrancyGuard {
     });
   });
 
+  describe('sol-013: Unsafe Timestamp Dependency', () => {
+    it('should detect unsafe reliance on block.timestamp and now in critical logic', async () => {
+      const code = `
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract TimeSensitive {
+    uint256 public deadline;
+
+    function bid() external {
+        require(block.timestamp <= deadline, "Auction expired");
+        // bidding logic
+    }
+
+    function recordStart() external {
+        uint256 startTime = now;
+        // start logic
+    }
+}
+`;
+
+      const result = await analyzer.analyze(code, 'time-sensitive.sol');
+      RuleAssertions.assertHasFinding(result.findings, 'sol-013');
+      RuleAssertions.assertFindingSeverity(result.findings, 'sol-013', 'high');
+    });
+
+    it('should not flag block.timestamp when used only for event emission', async () => {
+      const code = `
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract LogTimestamp {
+    event Timestamped(uint256 timestamp);
+
+    function log() external {
+        emit Timestamped(block.timestamp);
+    }
+}
+`;
+
+      const result = await analyzer.analyze(code, 'timestamp-log.sol');
+      RuleAssertions.assertNotHasFinding(result.findings, 'sol-013');
+    });
+  });
+
   describe('Rule Assertions', () => {
     it('should provide helpful assertion messages', async () => {
       const code = `


### PR DESCRIPTION
## Updates implemented

- Added a new Solidity rule `sol-013`:
  - `name`: `Unsafe Timestamp Dependency`
  - `category`: `security`
  - `severity`: `high`
  - Detects `block.timestamp` and `now` usage in critical control flow
  - Skips timestamp use in simple event emission lines

- Implemented the detection logic in:
  - solidity-analyzer.ts

- Added regression tests in:
  - solidity-rules.spec.ts

## Notes

- The rule now flags insecure timestamp-based logic such as `require(block.timestamp <= deadline, ...)` and `uint256 startTime = now;`
- It avoids false positives for lines that only emit a timestamp event

If you want, I can also add a dedicated fixture for `sol-013` and/or update rule documentation.

Made changes.

Closes #308 

## Done

Added a new tx.origin authentication rule for Solidity.

### What changed

- solidity-analyzer.ts
  - Added rule `sol-014`:
    - `name`: `Insecure tx.origin Authentication`
    - `severity`: `high`
    - `category`: `security`
    - `description`: flags `tx.origin` usage and suggests `msg.sender`
  - Implemented detection method `detectTxOriginUsage(code)`
    - flags raw `tx.origin` usage
    - ignores commented lines
  - Wired the rule into `analyze(...)` so findings are reported

- solidity-rules.spec.ts
  - Added regression tests for:
    - detecting `tx.origin` authentication use
    - not flagging `msg.sender` authentication

### Notes

Closes #309

- This meets the acceptance criteria: `tx.origin` usage is now flagged.
- I attempted to run the focused rule tests, but the terminal execution tool was skipped in this session.

Made changes.

Closes #306 