### PR TITLE
feat: detect dead code paths (fixes #302)

### DIFF
--- a/libs/engine/analyzers/solidity-analyzer.ts
+++ b/libs/engine/analyzers/solidity-analyzer.ts
@@ -152,6 +152,16 @@ export class SolidityAnalyzer extends BaseAnalyzer implements Analyzer {
       tags: ['events', 'auditability', 'transparency'],
       documentationUrl: 'https://docs.gasguard.dev/rules/sol-012',
     },
+    {
+      id: 'sol-015',
+      name: 'Dead Code Paths',
+      description: 'Identifies unreachable code paths that increase maintenance complexity and may indicate logic errors',
+      severity: Severity.MEDIUM,
+      category: 'maintainability',
+      enabled: true,
+      tags: ['dead-code', 'maintainability', 'unreachable'],
+      documentationUrl: 'https://docs.gasguard.dev/rules/sol-015',
+    },
   ];
   
   getName(): string {
@@ -395,6 +405,25 @@ export class SolidityAnalyzer extends BaseAnalyzer implements Analyzer {
             description: 'Add event emissions for state changes.',
             codeSnippet: 'event StateChanged(address indexed user, uint256 amount);\n...\nemit StateChanged(msg.sender, value);',
             documentationUrl: 'https://docs.gasguard.dev/rules/sol-012',
+          },
+        })));
+      }
+      
+      // Rule: sol-015 - Dead Code Paths
+      if (this.isRuleEnabled('sol-015', config)) {
+        const deadCodePaths = this.detectDeadCodePaths(code);
+        findings.push(...deadCodePaths.map(location => ({
+          ruleId: 'sol-015',
+          message: location.message,
+          severity: this.getRuleSeverity('sol-015', config),
+          location: {
+            file: filePath,
+            startLine: location.startLine,
+            endLine: location.endLine,
+          },
+          suggestedFix: {
+            description: location.suggestedFix,
+            documentationUrl: 'https://docs.gasguard.dev/rules/sol-015',
           },
         })));
       }
@@ -1199,6 +1228,71 @@ export class SolidityAnalyzer extends BaseAnalyzer implements Analyzer {
       }
     }
     
+    return findings;
+  }
+
+  /**
+   * Detects dead code paths (sol-015):
+   * Identifies unreachable code after unconditional exit statements
+   */
+  private detectDeadCodePaths(code: string): Array<{ startLine: number; endLine: number; message: string; suggestedFix: string }> {
+    const findings: Array<{ startLine: number; endLine: number; message: string; suggestedFix: string }> = [];
+    const lines = code.split('\n');
+    
+    const functionPattern = /^\s*function\s+(\w+)\s*\(/;
+    
+    for (let i = 0; i < lines.length; i++) {
+      const funcMatch = lines[i].match(functionPattern);
+      if (!funcMatch) continue;
+      
+      const functionName = funcMatch[1];
+      let braceDepth = 0;
+      let bodyStarted = false;
+      const bodyLines: Array<{ line: string; num: number; depth: number }> = [];
+      
+      for (let j = i; j < lines.length; j++) {
+        const cl = lines[j];
+        const opens = (cl.match(/\{/g) || []).length;
+        const closes = (cl.match(/\}/g) || []).length;
+        if (opens > 0) bodyStarted = true;
+        braceDepth += opens - closes;
+        if (bodyStarted) bodyLines.push({ line: cl, num: j + 1, depth: braceDepth });
+        if (bodyStarted && braceDepth === 0) break;
+      }
+      
+      let exitFoundAtLine = -1;
+      let exitDepth = -1;
+      
+      for (const bl of bodyLines) {
+        const trimmed = bl.line.trim();
+        if (!trimmed || trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed === '{' || trimmed === '}') continue;
+        
+        const isUnconditionalExit =
+          /^\s*return\b(?!s)/.test(bl.line) ||
+          /^\s*revert\b/.test(bl.line) ||
+          /^\s*selfdestruct\s*\(/.test(bl.line);
+        
+        if (isUnconditionalExit && bl.depth === 1) {
+          exitFoundAtLine = bl.num;
+          exitDepth = bl.depth;
+        }
+      }
+      
+      if (exitFoundAtLine > 0) {
+        for (const bl of bodyLines) {
+          const trimmed = bl.line.trim();
+          if (bl.num > exitFoundAtLine && bl.depth <= exitDepth && !trimmed.startsWith('//') && !trimmed.startsWith('*') && trimmed !== '' && trimmed !== '{' && trimmed !== '}') {
+            findings.push({
+              startLine: exitFoundAtLine,
+              endLine: bl.num,
+              message: `Unreachable code detected in function '${functionName}' after unconditional exit at line ${exitFoundAtLine}`,
+              suggestedFix: `Remove unreachable code after return/revert statement at line ${exitFoundAtLine}`,
+            });
+            break;
+          }
+        }
+      }
+    }
     return findings;
   }
 }

--- a/tests/rules/solidity-rules.spec.ts
+++ b/tests/rules/solidity-rules.spec.ts
@@ -163,6 +163,68 @@ contract TestContract {
     });
   });
 
+  // Helper config to isolate a single rule by disabling all others
+  function isolateRule(ruleId: string): any {
+    const allRuleIds = [
+      'sol-003', 'sol-004', 'sol-005', 'sol-006', 'sol-007',
+      'sol-008', 'sol-009', 'sol-010', 'sol-011', 'sol-012',
+      'sol-015'
+    ];
+    const rules: any = {};
+    for (const id of allRuleIds) {
+      rules[id] = { enabled: id === ruleId };
+    }
+    return { rules };
+  }
+
+  describe('sol-015: Dead Code Paths', () => {
+    it('should detect dead code after return/revert statements', async () => {
+      const code = `
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract TestContract {
+    function revertBefore() external {
+        revert("always revert");
+        uint256 x = 200;
+    }
+
+    function returnEarly() external {
+        return;
+        uint256 y = 300;
+    }
+}
+`;
+
+      const result = await analyzer.analyze(code, 'test015.sol', isolateRule('sol-015'));
+      
+      RuleAssertions.assertHasFinding(result.findings, 'sol-015');
+      const sol015Findings = result.findings.filter(f => f.ruleId === 'sol-015');
+      expect(sol015Findings.length).toBe(2);
+    });
+
+    it('should NOT flag clean code without dead paths', async () => {
+      const code = `
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract CleanContract {
+    function setValue(uint256 newValue) external {
+        // no dead code
+    }
+
+    function getValue() external view returns (uint256) {
+        return 42;
+    }
+}
+`;
+
+      const result = await analyzer.analyze(code, 'clean.sol', isolateRule('sol-015'));
+      
+      RuleAssertions.assertNotHasFinding(result.findings, 'sol-015');
+    });
+  });
+
   describe('Batch Testing', () => {
     it('should run multiple fixtures and generate report', async () => {
       const fixtures = FixtureLoader.loadFixturesFromDir(


### PR DESCRIPTION
Closes #302

Implements sol-015 rule to detect unreachable code after unconditional return/revert statements.