### PR TITLE
feat: Detect Inefficient Mapping Iteration Workarounds (#342)

### DIFF
--- a/.github/workflows/gasguard.yml
+++ b/.github/workflows/gasguard.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install GasGuard
         run: |
-          cargo install --path apps/api --bin gasguard
+          cargo install --force --path apps/api --bin gasguard
 
       - name: Run GasGuard Scan
         run: |

--- a/packages/rules/src/lib.rs
+++ b/packages/rules/src/lib.rs
@@ -18,7 +18,8 @@ pub use rule_engine::{
     extract_struct_fields, find_variable_usage, Rule, RuleEngine, RuleViolation, ViolationSeverity,
 };
 pub use security::{HardcodedAddressesRule, MissingDomainSeparationRule};
-pub use solidity::StateVariablePackingRule;
+pub use solidity::{StateVariablePackingRule, MappingIterationRule};
+pub use optimization::storage::detect_mapping_iteration;
 pub use unused_state_variables::UnusedStateVariablesRule;
 
 // Export Soroban types specifically

--- a/packages/rules/src/optimization/storage/mapping_iteration.rs
+++ b/packages/rules/src/optimization/storage/mapping_iteration.rs
@@ -1,0 +1,112 @@
+use gasguard_ast::{Language, UnifiedAST};
+use crate::rule_engine::{RuleViolation, ViolationSeverity};
+
+/// Detects inefficient mapping iteration workarounds.
+pub fn detect_mapping_iteration(ast: &UnifiedAST) -> Vec<RuleViolation> {
+    let mut violations = Vec::new();
+
+    if ast.language != Language::Solidity {
+        return violations;
+    }
+
+    for contract in &ast.contracts {
+        let mut mappings = Vec::new();
+        let mut arrays = Vec::new();
+
+        for var in &contract.state_variables {
+            if var.type_name.starts_with("mapping") {
+                mappings.push(&var.name);
+            } else if var.type_name.ends_with("[]") {
+                arrays.push(&var.name);
+            }
+        }
+
+        for func in &contract.functions {
+            let body = &func.body_raw;
+            // Simple check for loop keywords
+            if body.contains("for ") || body.contains("for(") || body.contains("while ") || body.contains("while(") {
+                for mapping in &mappings {
+                    for array in &arrays {
+                        // Look for mapping[array[i]] pattern
+                        let pattern1 = format!("{}[{}[", mapping, array);
+                        let pattern2 = format!("{}[ {}[", mapping, array); // e.g. mapping[ array[
+                        let pattern3 = format!("{} [{}[", mapping, array); // e.g. mapping [array[
+                        
+                        if body.contains(&pattern1) || body.contains(&pattern2) || body.contains(&pattern3) {
+                            violations.push(RuleViolation {
+                                rule_name: "mapping-iteration-workaround".to_string(),
+                                description: format!(
+                                    "Detected gas-heavy iteration over helper array '{}' to access mapping '{}'",
+                                    array, mapping
+                                ),
+                                severity: ViolationSeverity::High,
+                                line_number: func.line_number,
+                                column_number: 1,
+                                variable_name: mapping.to_string(),
+                                suggestion: "Mappings are not iterable. On-chain iteration over unbounded arrays can lead to out-of-gas errors. Consider using off-chain indexing via events or a pagination pattern.".to_string(),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    violations
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gasguard_ast::{ContractNode, FunctionNode, VariableNode, Visibility};
+
+    #[test]
+    fn test_detect_mapping_iteration() {
+        let ast = UnifiedAST {
+            language: Language::Solidity,
+            source: "".to_string(),
+            file_path: "".to_string(),
+            structs: vec![],
+            enums: vec![],
+            contracts: vec![ContractNode {
+                name: "Test".to_string(),
+                line_number: 1,
+                state_variables: vec![
+                    VariableNode {
+                        name: "balances".to_string(),
+                        type_name: "mapping(address => uint256)".to_string(),
+                        visibility: Visibility::Public,
+                        is_constant: false,
+                        is_immutable: false,
+                        line_number: 2,
+                    },
+                    VariableNode {
+                        name: "users".to_string(),
+                        type_name: "address[]".to_string(),
+                        visibility: Visibility::Public,
+                        is_constant: false,
+                        is_immutable: false,
+                        line_number: 3,
+                    },
+                ],
+                functions: vec![FunctionNode {
+                    name: "distribute".to_string(),
+                    params: vec![],
+                    return_type: None,
+                    visibility: Visibility::Public,
+                    decorators: vec![],
+                    is_constructor: false,
+                    is_external: false,
+                    is_payable: false,
+                    line_number: 5,
+                    body_raw: "for (uint i = 0; i < users.length; i++) { balances[users[i]] += 100; }".to_string(),
+                }],
+            }],
+        };
+
+        let violations = detect_mapping_iteration(&ast);
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].variable_name, "balances");
+        assert!(violations[0].description.contains("users"));
+    }
+}

--- a/packages/rules/src/optimization/storage/mod.rs
+++ b/packages/rules/src/optimization/storage/mod.rs
@@ -1,6 +1,9 @@
 pub mod state_variable_packing;
+pub mod multiple_storage_reads;
+pub mod mapping_iteration;
 
 pub use state_variable_packing::{
     detect_packing_opportunities, find_consecutive_packable_groups, get_type_size,
     is_packable_type, PackingOpportunity, VariableInfo,
 };
+pub use mapping_iteration::detect_mapping_iteration;

--- a/packages/rules/src/solidity/mapping_iteration.rs
+++ b/packages/rules/src/solidity/mapping_iteration.rs
@@ -1,0 +1,40 @@
+use crate::optimization::storage::detect_mapping_iteration;
+use crate::rule_engine::{Rule, RuleViolation};
+use gasguard_ast::UnifiedAST;
+use syn::Item;
+
+pub struct MappingIterationRule;
+
+impl Rule for MappingIterationRule {
+    fn name(&self) -> &str {
+        "mapping-iteration-workaround"
+    }
+
+    fn description(&self) -> &str {
+        "Detects iteration over a helper array used as keys for mapping access, which is highly gas-inefficient."
+    }
+
+    fn check(&self, _ast: &[Item]) -> Vec<RuleViolation> {
+        // Fallback for syn-based generic interface if needed.
+        // The main implementation relies on UnifiedAST via analyze().
+        Vec::new()
+    }
+}
+
+impl MappingIterationRule {
+    pub fn analyze(&self, ast: &UnifiedAST) -> Vec<RuleViolation> {
+        detect_mapping_iteration(ast)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mapping_iteration_rule() {
+        let rule = MappingIterationRule;
+        assert_eq!(rule.name(), "mapping-iteration-workaround");
+        assert!(rule.description().contains("iteration"));
+    }
+}

--- a/packages/rules/src/solidity/mod.rs
+++ b/packages/rules/src/solidity/mod.rs
@@ -1,4 +1,6 @@
 pub mod state_variable_packing;
 pub mod uint8_vs_uint256;
+pub mod mapping_iteration;
 
 pub use state_variable_packing::StateVariablePackingRule;
+pub use mapping_iteration::MappingIterationRule;


### PR DESCRIPTION
Closes #342 
 
### Summary 
This PR adds the MappingIterationRule to detect gas-heavy mapping iteration workarounds where developers use an unbounded helper array to simulate mapping iterability on-chain. This rule will alert developers and suggest off-chain solutions or pagination.
