### PR TITLE
feat: add Soroban refactor suggestions

### DIFF
--- a/src/refactors/stellar/index.ts
+++ b/src/refactors/stellar/index.ts
@@ -1,0 +1,2 @@
+export * from "./types";
+export * from "./refactor-suggestion-engine";

--- a/src/refactors/stellar/refactor-suggestion-engine.spec.ts
+++ b/src/refactors/stellar/refactor-suggestion-engine.spec.ts
@@ -1,0 +1,97 @@
+import { StellarRefactorSuggestionEngine } from "./refactor-suggestion-engine";
+import { RefactorFindingInput } from "./types";
+
+describe("StellarRefactorSuggestionEngine", () => {
+  const engine = new StellarRefactorSuggestionEngine();
+
+  it("detects repeated finding patterns and links them back to findings", () => {
+    const findings: RefactorFindingInput[] = [
+      {
+        ruleId: "SOR-001",
+        message: "Repeated state variable access in loop",
+        filePath: "contracts/vault.rs",
+        line: 10,
+        confidence: 0.91,
+      },
+      {
+        ruleId: "SOR-001",
+        message: "Expensive state variable access in loop",
+        filePath: "contracts/vault.rs",
+        line: 20,
+        confidence: 0.92,
+      },
+    ];
+
+    const suggestions = engine.suggestForFindings(findings);
+
+    const repeated = suggestions.find((suggestion) =>
+      suggestion.title.includes("Consolidate repeated SOR-001"),
+    );
+    expect(repeated).toBeDefined();
+    expect(repeated?.relatedFindingIds).toHaveLength(2);
+    expect(repeated?.locations).toEqual([
+      { file: "contracts/vault.rs", startLine: 10, endLine: undefined },
+      { file: "contracts/vault.rs", startLine: 20, endLine: undefined },
+    ]);
+  });
+
+  it("generates actionable suggestions from rule messages and suggested fixes", () => {
+    const findings: RefactorFindingInput[] = [
+      {
+        ruleId: "SOR-AUTH",
+        message: "Missing owner authorization check before admin action",
+        location: {
+          file: "contracts/admin.rs",
+          startLine: 42,
+          endLine: 44,
+        },
+        severity: "high",
+        suggestedFix: {
+          description:
+            "Require owner authorization before mutating admin state.",
+        },
+      },
+    ];
+
+    const suggestions = engine.suggestForFindings(findings);
+
+    expect(suggestions.map((suggestion) => suggestion.category)).toEqual(
+      expect.arrayContaining(["authorization", "rule-fix"]),
+    );
+    expect(
+      suggestions.every(
+        (suggestion) => suggestion.relatedFindingIds.length > 0,
+      ),
+    ).toBe(true);
+    expect(suggestions[0].reportText).toContain(suggestions[0].title);
+  });
+
+  it("attaches only related suggestions to each finding", () => {
+    const findings: RefactorFindingInput[] = [
+      {
+        ruleId: "SOR-ERR",
+        message: "unwrap can panic on invalid payload",
+        filePath: "contracts/router.rs",
+        line: 7,
+      },
+      {
+        ruleId: "SOR-PERF",
+        message: "cache expensive state variable access in loop",
+        filePath: "contracts/router.rs",
+        line: 15,
+      },
+    ];
+
+    const augmented = engine.attachSuggestionsToFindings(findings);
+
+    expect(
+      augmented[0].refactorSuggestions.map((suggestion) => suggestion.category),
+    ).toContain("error-handling");
+    expect(
+      augmented[0].refactorSuggestions.map((suggestion) => suggestion.category),
+    ).not.toContain("performance");
+    expect(
+      augmented[1].refactorSuggestions.map((suggestion) => suggestion.category),
+    ).toContain("performance");
+  });
+});

--- a/src/refactors/stellar/refactor-suggestion-engine.ts
+++ b/src/refactors/stellar/refactor-suggestion-engine.ts
@@ -1,0 +1,279 @@
+import {
+  FindingWithRefactorSuggestions,
+  RefactorFindingInput,
+  RefactorSuggestion,
+  RefactorSuggestionCategory,
+  RefactorSuggestionEffort,
+  RefactorSuggestionLocation,
+  RefactorSuggestionOptions,
+  RefactorSuggestionPriority,
+} from "./types";
+
+const DEFAULT_REPEATED_FINDING_THRESHOLD = 2;
+
+export class StellarRefactorSuggestionEngine {
+  suggestForFindings(
+    findings: RefactorFindingInput[],
+    options: RefactorSuggestionOptions = {},
+  ): RefactorSuggestion[] {
+    const suggestions = new Map<string, RefactorSuggestion>();
+    const threshold =
+      options.repeatedFindingThreshold ?? DEFAULT_REPEATED_FINDING_THRESHOLD;
+
+    for (const suggestion of this.detectRepeatedPatterns(findings, threshold)) {
+      suggestions.set(suggestion.id, suggestion);
+    }
+
+    findings.forEach((finding, index) => {
+      for (const suggestion of this.detectFindingSuggestions(finding, index)) {
+        suggestions.set(suggestion.id, suggestion);
+      }
+    });
+
+    return Array.from(suggestions.values()).sort((a, b) => {
+      const priorityOrder: Record<RefactorSuggestionPriority, number> = {
+        high: 0,
+        medium: 1,
+        low: 2,
+      };
+      return (
+        priorityOrder[a.priority] - priorityOrder[b.priority] ||
+        a.id.localeCompare(b.id)
+      );
+    });
+  }
+
+  attachSuggestionsToFindings<T extends RefactorFindingInput>(
+    findings: T[],
+    options: RefactorSuggestionOptions = {},
+  ): Array<FindingWithRefactorSuggestions<T>> {
+    const suggestions = this.suggestForFindings(findings, options);
+
+    return findings.map((finding, index) => {
+      const findingId = this.findingId(finding, index);
+      return {
+        ...finding,
+        refactorSuggestions: suggestions.filter((suggestion) =>
+          suggestion.relatedFindingIds.includes(findingId),
+        ),
+      };
+    });
+  }
+
+  private detectRepeatedPatterns(
+    findings: RefactorFindingInput[],
+    threshold: number,
+  ): RefactorSuggestion[] {
+    const groups = new Map<
+      string,
+      Array<{ finding: RefactorFindingInput; index: number }>
+    >();
+
+    findings.forEach((finding, index) => {
+      const key = `${finding.ruleId}:${this.findingFile(finding)}`;
+      const group = groups.get(key) ?? [];
+      group.push({ finding, index });
+      groups.set(key, group);
+    });
+
+    return Array.from(groups.values())
+      .filter((group) => group.length >= threshold)
+      .map((group) => {
+        const first = group[0].finding;
+        const file = this.findingFile(first);
+        const relatedFindingIds = group.map(({ finding, index }) =>
+          this.findingId(finding, index),
+        );
+        const locations = group.map(({ finding }) =>
+          this.findingLocation(finding),
+        );
+
+        return this.createSuggestion({
+          category: "repeated-pattern",
+          description:
+            `Rule ${first.ruleId} appears ${group.length} times in ${file}. ` +
+            "Consider extracting a shared helper or guard so the same remediation is made once and reused.",
+          effort: group.length > 3 ? "large" : "medium",
+          locations,
+          priority: group.length > 3 ? "high" : "medium",
+          relatedFindingIds,
+          title: `Consolidate repeated ${first.ruleId} remediation`,
+        });
+      });
+  }
+
+  private detectFindingSuggestions(
+    finding: RefactorFindingInput,
+    index: number,
+  ): RefactorSuggestion[] {
+    const message = finding.message.toLowerCase();
+    const relatedFindingIds = [this.findingId(finding, index)];
+    const locations = [this.findingLocation(finding)];
+    const suggestions: RefactorSuggestion[] = [];
+
+    if (finding.suggestedFix?.description) {
+      suggestions.push(
+        this.createSuggestion({
+          category: "rule-fix",
+          description: `${finding.suggestedFix.description} Promote this fix into a reusable helper, rule fixture, or documented pattern if the same rule can recur elsewhere.`,
+          effort: "small",
+          locations,
+          priority: this.priorityFromFinding(finding, "medium"),
+          relatedFindingIds,
+          title: `Turn ${finding.ruleId} fix into a reusable pattern`,
+        }),
+      );
+    }
+
+    if (
+      this.matchesAny(message, ["loop", "cache", "expensive", "state variable"])
+    ) {
+      suggestions.push(
+        this.createSuggestion({
+          category: "performance",
+          description:
+            "Move repeated reads or expensive computation out of hot paths, cache stable values locally, and add a regression test for the optimized path.",
+          effort: "medium",
+          locations,
+          priority: this.priorityFromFinding(finding, "medium"),
+          relatedFindingIds,
+          title: "Extract hot-path computation into a cached helper",
+        }),
+      );
+    }
+
+    if (
+      this.matchesAny(message, [
+        "authorization",
+        "permission",
+        "owner",
+        "admin",
+        "access control",
+      ])
+    ) {
+      suggestions.push(
+        this.createSuggestion({
+          category: "authorization",
+          description:
+            "Centralize authorization checks behind a named guard so future call sites share the same owner/admin policy and failure behavior.",
+          effort: "medium",
+          locations,
+          priority: this.priorityFromFinding(finding, "high"),
+          relatedFindingIds,
+          title: "Centralize authorization policy checks",
+        }),
+      );
+    }
+
+    if (
+      this.matchesAny(message, [
+        "unwrap",
+        "expect",
+        "panic",
+        "error",
+        "failure",
+      ])
+    ) {
+      suggestions.push(
+        this.createSuggestion({
+          category: "error-handling",
+          description:
+            "Replace ad-hoc failure handling with a typed error path and add coverage for the failure branch so reports remain actionable instead of crash-driven.",
+          effort: "small",
+          locations,
+          priority: this.priorityFromFinding(finding, "medium"),
+          relatedFindingIds,
+          title: "Normalize failure handling around typed errors",
+        }),
+      );
+    }
+
+    return suggestions;
+  }
+
+  private createSuggestion(input: {
+    category: RefactorSuggestionCategory;
+    description: string;
+    effort: RefactorSuggestionEffort;
+    locations: RefactorSuggestionLocation[];
+    priority: RefactorSuggestionPriority;
+    relatedFindingIds: string[];
+    title: string;
+  }): RefactorSuggestion {
+    const locationKey = input.locations
+      .map((location) => `${location.file}:${location.startLine ?? 0}`)
+      .join("|");
+    const id = this.slug(
+      [
+        input.category,
+        input.title,
+        input.relatedFindingIds.join("|"),
+        locationKey,
+      ].join(":"),
+    );
+
+    return {
+      ...input,
+      id,
+      reportText: `${input.title}: ${input.description}`,
+    };
+  }
+
+  private findingId(finding: RefactorFindingInput, index: number): string {
+    return this.slug(
+      [
+        finding.ruleId,
+        this.findingFile(finding),
+        this.findingLine(finding) ?? index + 1,
+        index,
+      ].join(":"),
+    );
+  }
+
+  private findingFile(finding: RefactorFindingInput): string {
+    return finding.location?.file ?? finding.filePath ?? "unknown";
+  }
+
+  private findingLine(finding: RefactorFindingInput): number | undefined {
+    return finding.location?.startLine ?? finding.line;
+  }
+
+  private findingLocation(
+    finding: RefactorFindingInput,
+  ): RefactorSuggestionLocation {
+    return {
+      file: this.findingFile(finding),
+      startLine: this.findingLine(finding),
+      endLine: finding.location?.endLine,
+    };
+  }
+
+  private matchesAny(message: string, keywords: string[]): boolean {
+    return keywords.some((keyword) => message.includes(keyword));
+  }
+
+  private priorityFromFinding(
+    finding: RefactorFindingInput,
+    fallback: RefactorSuggestionPriority,
+  ): RefactorSuggestionPriority {
+    const severity = finding.severity?.toLowerCase();
+    if (severity === "critical" || severity === "high") {
+      return "high";
+    }
+    if (severity === "low" || severity === "info") {
+      return "low";
+    }
+    if (typeof finding.confidence === "number" && finding.confidence >= 0.85) {
+      return "high";
+    }
+    return fallback;
+  }
+
+  private slug(value: string): string {
+    return value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 96);
+  }
+}

--- a/src/refactors/stellar/types.ts
+++ b/src/refactors/stellar/types.ts
@@ -1,0 +1,59 @@
+export type RefactorSuggestionPriority = "high" | "medium" | "low";
+
+export type RefactorSuggestionEffort = "small" | "medium" | "large";
+
+export type RefactorSuggestionCategory =
+  | "authorization"
+  | "error-handling"
+  | "performance"
+  | "repeated-pattern"
+  | "rule-fix";
+
+export interface RefactorFindingLocation {
+  file: string;
+  startLine: number;
+  endLine?: number;
+}
+
+export interface RefactorFindingInput {
+  ruleId: string;
+  message: string;
+  filePath?: string;
+  line?: number;
+  location?: RefactorFindingLocation;
+  severity?: string;
+  confidence?: number;
+  suggestedFix?: {
+    description: string;
+    codeSnippet?: string;
+    documentationUrl?: string;
+  };
+  metadata?: Record<string, unknown>;
+}
+
+export interface RefactorSuggestionLocation {
+  file: string;
+  startLine?: number;
+  endLine?: number;
+}
+
+export interface RefactorSuggestion {
+  id: string;
+  title: string;
+  description: string;
+  category: RefactorSuggestionCategory;
+  priority: RefactorSuggestionPriority;
+  effort: RefactorSuggestionEffort;
+  relatedFindingIds: string[];
+  locations: RefactorSuggestionLocation[];
+  reportText: string;
+}
+
+export type FindingWithRefactorSuggestions<T extends RefactorFindingInput> =
+  T & {
+    refactorSuggestions: RefactorSuggestion[];
+  };
+
+export interface RefactorSuggestionOptions {
+  repeatedFindingThreshold?: number;
+}

--- a/src/reporting/html/html-reporter.spec.ts
+++ b/src/reporting/html/html-reporter.spec.ts
@@ -1,56 +1,64 @@
-/**
- * HTML Reporter Test
- * 
- * Demonstrates generating a human-readable report.
- */
+import { HtmlReporter } from "./html-reporter";
+import { ReportIssue } from "./types";
 
-import { HtmlReporter } from './html-reporter';
-import * as path from 'path';
-
-async function runDemo() {
+describe("HtmlReporter refactor suggestions", () => {
   const reporter = new HtmlReporter();
-  
-  const sampleIssues = [
+
+  const sampleIssues: ReportIssue[] = [
     {
-      ruleId: 'GAS-001',
-      filePath: 'contracts/Vulnerable.sol',
+      ruleId: "SOR-PERF",
+      filePath: "contracts/vault.rs",
       line: 42,
-      message: 'Unchecked loop variable increment leading to potential gas exhaustion.',
-      confidence: 0.95
+      message: "Expensive state variable access in loop should be cached.",
+      confidence: 0.95,
     },
     {
-      ruleId: 'GAS-002',
-      filePath: 'contracts/Vulnerable.sol',
-      line: 128,
-      message: 'Expensive state variable access in loop. Consider caching in memory.',
-      confidence: 0.82
-    },
-    {
-      ruleId: 'SEC-005',
-      filePath: 'contracts/Auth.sol',
+      ruleId: "SOR-AUTH",
+      filePath: "contracts/admin.rs",
       line: 12,
-      message: 'Implicit visibility for state variable. Should be explicitly public or private.',
-      confidence: 0.45
-    }
+      message: "Missing owner authorization check before admin action.",
+      confidence: 0.88,
+    },
   ];
 
-  const reportData = reporter.createReportData(
-    'StellarAid-Web',
-    'v1.2.0-beta',
-    sampleIssues,
-    156, // total files
-    2450 // duration ms
-  );
+  it("adds linked refactor suggestions to report data", () => {
+    const data = reporter.createReportData(
+      "GasGuard Soroban Scan",
+      "v1.0.0",
+      sampleIssues,
+      12,
+      140,
+    );
 
-  const outputPath = path.join(process.cwd(), 'reports', 'analysis-report.html');
-  console.log(`Generating report at: ${outputPath}`);
-  
-  await reporter.saveReport(reportData, outputPath);
-  console.log('Report generated successfully!');
-}
+    expect(
+      data.refactorSuggestions?.map((suggestion) => suggestion.category),
+    ).toEqual(expect.arrayContaining(["authorization", "performance"]));
+    expect(
+      data.issues[0].refactorSuggestions?.map(
+        (suggestion) => suggestion.category,
+      ),
+    ).toContain("performance");
+    expect(
+      data.issues[1].refactorSuggestions?.map(
+        (suggestion) => suggestion.category,
+      ),
+    ).toContain("authorization");
+  });
 
-if (require.main === module) {
-  runDemo().catch(console.error);
-}
+  it("renders refactor suggestions in the HTML report", () => {
+    const data = reporter.createReportData(
+      "GasGuard Soroban Scan",
+      "v1.0.0",
+      sampleIssues,
+      12,
+      140,
+    );
 
-export { runDemo };
+    const html = reporter.generate(data);
+
+    expect(html).toContain("Refactor Suggestions");
+    expect(html).toContain("Extract hot-path computation into a cached helper");
+    expect(html).toContain("Centralize authorization policy checks");
+    expect(html).toContain("Related refactors");
+  });
+});

--- a/src/reporting/html/html-reporter.ts
+++ b/src/reporting/html/html-reporter.ts
@@ -1,15 +1,19 @@
 /**
  * HTML Reporter
- * 
+ *
  * Generates human-readable HTML reports from analysis results.
  */
 
-import { ReportData } from './types';
-import { getReportTemplate } from './template';
-import * as fs from 'fs';
-import * as path from 'path';
+import { StellarRefactorSuggestionEngine } from "../../refactors/stellar";
+import { ReportData, ReportIssue } from "./types";
+import { getReportTemplate } from "./template";
+import * as fs from "fs";
+import * as path from "path";
 
 export class HtmlReporter {
+  private readonly refactorSuggestionEngine =
+    new StellarRefactorSuggestionEngine();
+
   /**
    * Generate an HTML report string
    */
@@ -22,14 +26,14 @@ export class HtmlReporter {
    */
   async saveReport(data: ReportData, outputPath: string): Promise<string> {
     const html = this.generate(data);
-    
+
     // Ensure directory exists
     const dir = path.dirname(outputPath);
     if (!fs.existsSync(dir)) {
       fs.mkdirSync(dir, { recursive: true });
     }
 
-    fs.writeFileSync(outputPath, html, 'utf8');
+    fs.writeFileSync(outputPath, html, "utf8");
     return outputPath;
   }
 
@@ -39,24 +43,34 @@ export class HtmlReporter {
   createReportData(
     projectName: string,
     version: string,
-    issues: any[],
+    issues: ReportIssue[],
     totalFiles: number,
-    durationMs: number
+    durationMs: number,
   ): ReportData {
+    const refactorSuggestions =
+      this.refactorSuggestionEngine.suggestForFindings(issues);
+    const issuesWithSuggestions =
+      this.refactorSuggestionEngine.attachSuggestionsToFindings(issues);
+
     return {
       projectName,
       version,
       metrics: {
         totalFiles,
         totalIssues: issues.length,
-        criticalIssues: issues.filter(i => i.confidence > 0.9).length,
-        highIssues: issues.filter(i => i.confidence > 0.7 && i.confidence <= 0.9).length,
-        mediumIssues: issues.filter(i => i.confidence > 0.5 && i.confidence <= 0.7).length,
-        lowIssues: issues.filter(i => i.confidence <= 0.5).length,
+        criticalIssues: issues.filter((i) => i.confidence > 0.9).length,
+        highIssues: issues.filter(
+          (i) => i.confidence > 0.7 && i.confidence <= 0.9,
+        ).length,
+        mediumIssues: issues.filter(
+          (i) => i.confidence > 0.5 && i.confidence <= 0.7,
+        ).length,
+        lowIssues: issues.filter((i) => i.confidence <= 0.5).length,
         scannedAt: new Date(),
-        durationMs
+        durationMs,
       },
-      issues
+      issues: issuesWithSuggestions,
+      refactorSuggestions,
     };
   }
 }

--- a/src/reporting/html/template.ts
+++ b/src/reporting/html/template.ts
@@ -1,8 +1,79 @@
 /**
  * HTML Report Template
- * 
+ *
  * A modern, responsive template for GasGuard analysis reports.
  */
+
+const escapeHtml = (value: unknown): string =>
+  String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+const renderLocation = (location: any): string => {
+  const line =
+    typeof location.startLine === "number" ? `:${location.startLine}` : "";
+  return `${escapeHtml(location.file)}${line}`;
+};
+
+const renderRefactorSuggestions = (suggestions: any[] = []): string => {
+  if (suggestions.length === 0) {
+    return "";
+  }
+
+  return `
+        <section class="refactor-section">
+            <div class="section-heading">
+                <h2>Refactor Suggestions</h2>
+                <span>${suggestions.length} linked recommendations</span>
+            </div>
+            <div class="suggestion-list">
+                ${suggestions
+                  .map(
+                    (suggestion) => `
+                    <article class="suggestion-card priority-${escapeHtml(suggestion.priority)}">
+                        <div class="suggestion-meta">
+                            <span>${escapeHtml(suggestion.priority)} priority</span>
+                            <span>${escapeHtml(suggestion.category)}</span>
+                            <span>${escapeHtml(suggestion.effort)} effort</span>
+                        </div>
+                        <h3>${escapeHtml(suggestion.title)}</h3>
+                        <p>${escapeHtml(suggestion.description)}</p>
+                        <div class="suggestion-locations">
+                            ${(suggestion.locations ?? []).map(renderLocation).join(" · ")}
+                        </div>
+                    </article>
+                `,
+                  )
+                  .join("")}
+            </div>
+        </section>
+  `;
+};
+
+const renderIssueRefactorLinks = (issue: any): string => {
+  const suggestions = issue.refactorSuggestions ?? [];
+  if (suggestions.length === 0) {
+    return "";
+  }
+
+  return `
+                        <div class="issue-refactors">
+                            <span>Related refactors</span>
+                            <ul>
+                                ${suggestions
+                                  .map(
+                                    (suggestion: any) => `
+                                    <li>${escapeHtml(suggestion.title)}</li>
+                                `,
+                                  )
+                                  .join("")}
+                            </ul>
+                        </div>
+  `;
+};
 
 export const getReportTemplate = (data: any) => `
 <!DOCTYPE html>
@@ -102,6 +173,75 @@ export const getReportTemplate = (data: any) => `
         .severity-medium { color: var(--medium); }
         .severity-low { color: var(--low); }
 
+        .section-heading {
+            display: flex;
+            justify-content: space-between;
+            gap: 1rem;
+            align-items: baseline;
+            margin-bottom: 1rem;
+        }
+
+        .section-heading span {
+            color: var(--text-muted);
+            font-size: 0.875rem;
+        }
+
+        .refactor-section {
+            margin-bottom: 2rem;
+        }
+
+        .suggestion-list {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+            gap: 1rem;
+        }
+
+        .suggestion-card {
+            background: var(--card-bg);
+            border: 1px solid var(--border);
+            border-top: 4px solid var(--info);
+            border-radius: 12px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+            padding: 1.25rem;
+        }
+
+        .suggestion-card.priority-high { border-top-color: var(--high); }
+        .suggestion-card.priority-medium { border-top-color: var(--medium); }
+        .suggestion-card.priority-low { border-top-color: var(--low); }
+
+        .suggestion-card h3 {
+            font-size: 1rem;
+            margin: 0.5rem 0;
+        }
+
+        .suggestion-card p {
+            color: var(--text-muted);
+            font-size: 0.925rem;
+        }
+
+        .suggestion-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.4rem;
+        }
+
+        .suggestion-meta span {
+            background: var(--bg);
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+            padding: 0.15rem 0.45rem;
+            text-transform: capitalize;
+        }
+
+        .suggestion-locations {
+            color: var(--text-muted);
+            font-family: monospace;
+            font-size: 0.75rem;
+            margin-top: 0.75rem;
+        }
+
         .issue-list {
             display: flex;
             flex-direction: column;
@@ -143,6 +283,34 @@ export const getReportTemplate = (data: any) => `
             font-size: 1rem;
             margin-bottom: 0.75rem;
         }
+
+        .issue-refactors {
+            background: var(--bg);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            margin-top: 0.75rem;
+            padding: 0.75rem;
+        }
+
+        .issue-refactors span {
+            color: var(--text-muted);
+            display: block;
+            font-size: 0.75rem;
+            font-weight: 700;
+            letter-spacing: 0.04em;
+            margin-bottom: 0.35rem;
+            text-transform: uppercase;
+        }
+
+        .issue-refactors ul {
+            margin-left: 1rem;
+        }
+
+        .issue-refactors li {
+            color: var(--text);
+            font-size: 0.875rem;
+        }
+
 
         .confidence-bar {
             height: 4px;
@@ -197,23 +365,30 @@ export const getReportTemplate = (data: any) => `
             </div>
         </div>
 
+        ${renderRefactorSuggestions(data.refactorSuggestions)}
+
         <h2 style="margin-bottom: 1.5rem">Detected Issues</h2>
         <div class="issue-list">
-            ${data.issues.map((issue: any) => \`
-                <div class="issue-card" style="border-left-color: \${issue.confidence > 0.8 ? 'var(--critical)' : 'var(--high)'}">
+            ${data.issues
+              .map(
+                (issue: any) => `
+                <div class="issue-card" style="border-left-color: ${issue.confidence > 0.8 ? "var(--critical)" : "var(--high)"}">
                     <div class="issue-header">
-                        <span class="rule-id">\${issue.ruleId}</span>
+                        <span class="rule-id">${escapeHtml(issue.ruleId)}</span>
                         <div style="display: flex; align-items: center; gap: 0.5rem">
-                            <span style="font-size: 0.75rem; color: var(--text-muted)">Confidence: \${Math.round(issue.confidence * 100)}%</span>
+                            <span style="font-size: 0.75rem; color: var(--text-muted)">Confidence: ${Math.round(issue.confidence * 100)}%</span>
                             <div class="confidence-bar">
-                                <div class="confidence-fill" style="width: \${issue.confidence * 100}%"></div>
+                                <div class="confidence-fill" style="width: ${issue.confidence * 100}%"></div>
                             </div>
                         </div>
                     </div>
-                    <div class="file-path">\${issue.filePath}:\${issue.line}</div>
-                    <div class="issue-message">\${issue.message}</div>
+                    <div class="file-path">${escapeHtml(issue.filePath)}:${issue.line}</div>
+                    <div class="issue-message">${escapeHtml(issue.message)}</div>
+                    ${renderIssueRefactorLinks(issue)}
                 </div>
-            \`).join('')}
+            `,
+              )
+              .join("")}
         </div>
 
         <div class="footer">
@@ -222,4 +397,4 @@ export const getReportTemplate = (data: any) => `
     </div>
 </body>
 </html>
-\`;
+	`;

--- a/src/reporting/html/types.ts
+++ b/src/reporting/html/types.ts
@@ -1,4 +1,9 @@
-import { AnalysisResult } from '../../analysis/filter/analysis-filter';
+import { AnalysisResult } from "../../analysis/filter/analysis-filter";
+import { RefactorSuggestion } from "../../refactors/stellar";
+
+export type ReportIssue = AnalysisResult & {
+  refactorSuggestions?: RefactorSuggestion[];
+};
 
 export interface ReportMetrics {
   totalFiles: number;
@@ -15,5 +20,6 @@ export interface ReportData {
   projectName: string;
   version: string;
   metrics: ReportMetrics;
-  issues: AnalysisResult[];
+  issues: ReportIssue[];
+  refactorSuggestions?: RefactorSuggestion[];
 }


### PR DESCRIPTION
## Summary

Closes #511.

Adds a focused Soroban refactor-suggestion layer under `src/refactors/stellar/` that:

- detects maintainability-oriented refactor opportunities from analysis findings
- generates suggestions for repeated rule/file patterns, reusable rule fixes, hot-path/cache concerns, authorization checks, and typed error handling
- links each suggestion back to the relevant findings
- includes refactor suggestions in the HTML report summary and under each related issue

## Validation

- `npx jest src/refactors/stellar/refactor-suggestion-engine.spec.ts src/reporting/html/html-reporter.spec.ts --runInBand`
- `npx tsc --noEmit --skipLibCheck --target ES2020 --module commonjs --moduleResolution node --esModuleInterop --strict src/refactors/stellar/types.ts src/refactors/stellar/refactor-suggestion-engine.ts src/reporting/html/types.ts src/reporting/html/html-reporter.ts src/reporting/html/template.ts`
- `git diff --check`
- `npx prettier --check src/refactors/stellar/index.ts src/refactors/stellar/refactor-suggestion-engine.spec.ts src/refactors/stellar/refactor-suggestion-engine.ts src/refactors/stellar/types.ts src/reporting/html/html-reporter.spec.ts src/reporting/html/html-reporter.ts src/reporting/html/template.ts src/reporting/html/types.ts`

I also tried `npm test -- --runInBand`. The full suite reported existing repo-wide failures unrelated to this change, including missing packages such as `@nestjs/passport`, `@nestjs/jwt`, `@nestjs/config`, `@nestjs/typeorm`, `typeorm`, path-resolution failures in existing specs, RPC provider mock failures, and then hung on Redis open handles, so I interrupted it after the failures were reported.
