### PR TITLE
feat(auditability): fix #321 by detecting duplicate event emissions

### DIFF
--- a/packages/rules/gasGuard/src/languages/solidity.analyzer.ts
+++ b/packages/rules/gasGuard/src/languages/solidity.analyzer.ts
@@ -1,5 +1,5 @@
-import { SolidityAnalyzer } from "@engine/analyzers";
 import { SolidityAnalyzer } from "../../../../../libs/engine/analyzers/solidity-analyzer";
+import { detectDuplicateEventEmissions } from "../../../../../rules/auditability/events/detect-duplicate-event-emissions";
 
 export class SolidityAnalyzerWrapper {
   private analyzer: SolidityAnalyzer;
@@ -18,6 +18,20 @@ export class SolidityAnalyzerWrapper {
       line: finding.location.startLine,
       suggestion: finding.suggestedFix?.description,
     }));
+
+    const duplicateEvents = detectDuplicateEventEmissions(source);
+    for (const violation of duplicateEvents.violations) {
+      issues.push({
+        ruleId: "detect-duplicate-event-emissions",
+        severity: "medium",
+        message: `Duplicate event emission detected at lines ${[
+          violation.firstLine,
+          ...violation.duplicateLines,
+        ].join(", ")}`,
+        line: violation.firstLine,
+        suggestion: duplicateEvents.suggestion,
+      });
+    }
 
     return { issues };
   }

--- a/packages/rules/gasGuard/src/languages/soroban.analyzer.ts
+++ b/packages/rules/gasGuard/src/languages/soroban.analyzer.ts
@@ -1,3 +1,5 @@
+import { detectDuplicateEventEmissions } from "../../../../../rules/auditability/events/detect-duplicate-event-emissions";
+
 export class SorobanAnalyzer {
   analyze(source: string) {
     const issues = [];
@@ -26,6 +28,19 @@ export class SorobanAnalyzer {
         severity: "low",
         message: "Unnecessary clone detected",
         suggestion: "Avoid cloning; return original or borrow",
+      });
+    }
+
+    const duplicateEvents = detectDuplicateEventEmissions(source);
+    for (const violation of duplicateEvents.violations) {
+      issues.push({
+        ruleId: "detect-duplicate-event-emissions",
+        severity: "medium",
+        message: `Duplicate event emission detected at lines ${[
+          violation.firstLine,
+          ...violation.duplicateLines,
+        ].join(", ")}`,
+        suggestion: duplicateEvents.suggestion,
       });
     }
 

--- a/rules/auditability/events/detect-duplicate-event-emissions.ts
+++ b/rules/auditability/events/detect-duplicate-event-emissions.ts
@@ -1,0 +1,354 @@
+export interface DuplicateEventEmissionResult {
+  detected: boolean;
+  violations: DuplicateEventEmissionViolation[];
+  message: string;
+  suggestion: string;
+}
+
+export interface DuplicateEventEmissionViolation {
+  eventKey: string;
+  count: number;
+  firstLine: number;
+  duplicateLines: number[];
+  snippets: string[];
+}
+
+interface EventEmission {
+  key: string;
+  line: number;
+  snippet: string;
+}
+
+interface ScanScope {
+  code: string;
+  startLine: number;
+  lineStarts: number[];
+}
+
+const MAX_SNIPPET_LENGTH = 120;
+
+export function detectDuplicateEventEmissions(code: string): DuplicateEventEmissionResult {
+  const violations: DuplicateEventEmissionViolation[] = [];
+
+  for (const scope of getScanScopes(code)) {
+    const emissions = extractEventEmissions(scope);
+    const grouped = groupByEventKey(emissions);
+
+    for (const [eventKey, matches] of grouped) {
+      if (matches.length < 2) continue;
+
+      violations.push({
+        eventKey,
+        count: matches.length,
+        firstLine: matches[0].line,
+        duplicateLines: matches.slice(1).map((match) => match.line),
+        snippets: matches.map((match) => match.snippet),
+      });
+    }
+  }
+
+  if (violations.length === 0) {
+    return {
+      detected: false,
+      violations: [],
+      message: 'No duplicate event emissions detected.',
+      suggestion: '',
+    };
+  }
+
+  return {
+    detected: true,
+    violations,
+    message: `Duplicate event emissions detected in ${violations.length} event pattern(s).`,
+    suggestion:
+      'Consolidate repeated event emissions into one publish or emit call after the state change has completed.',
+  };
+}
+
+function getScanScopes(code: string): ScanScope[] {
+  const scopes: ScanScope[] = [];
+  const sanitized = sanitizeCode(code);
+  const rootLineStarts = buildLineStarts(code);
+  const functionPattern =
+    /\b(?:function\s+[A-Za-z_$][\w$]*|constructor|fallback|receive|(?:pub\s+)?fn\s+[A-Za-z_][\w]*)[^{]*\{/g;
+
+  for (const match of sanitized.matchAll(functionPattern)) {
+    const openBrace = (match.index ?? 0) + match[0].length - 1;
+    const closeBrace = findMatching(sanitized, openBrace, '{', '}');
+    if (closeBrace === -1) continue;
+
+    scopes.push({
+      code: code.slice(openBrace + 1, closeBrace),
+      startLine: lineAt(openBrace + 1, rootLineStarts),
+      lineStarts: buildLineStarts(code.slice(openBrace + 1, closeBrace)),
+    });
+  }
+
+  return scopes.length > 0
+    ? scopes
+    : [{ code, startLine: 1, lineStarts: buildLineStarts(code) }];
+}
+
+function extractEventEmissions(scope: ScanScope): EventEmission[] {
+  return [
+    ...extractSolidityEmitCalls(scope),
+    ...extractSorobanPublishCalls(scope),
+    ...extractTypedSorobanPublishCalls(scope),
+  ];
+}
+
+function extractSolidityEmitCalls(scope: ScanScope): EventEmission[] {
+  const emissions: EventEmission[] = [];
+  const sanitized = sanitizeCode(scope.code);
+  const emitPattern = /\bemit\s+([A-Za-z_$][\w$]*)\s*\(/g;
+
+  for (const match of sanitized.matchAll(emitPattern)) {
+    const openParen = (match.index ?? 0) + match[0].lastIndexOf('(');
+    const closeParen = findMatching(sanitized, openParen, '(', ')');
+    if (closeParen === -1) continue;
+
+    const eventName = match[1];
+    const args = scope.code.slice(openParen + 1, closeParen);
+    const source = scope.code.slice(match.index ?? 0, closeParen + 1);
+
+    emissions.push({
+      key: `solidity:${eventName}:${normalizeExpression(args)}`,
+      line: scope.startLine + lineAt(match.index ?? 0, scope.lineStarts) - 1,
+      snippet: toSnippet(source),
+    });
+  }
+
+  return emissions;
+}
+
+function extractSorobanPublishCalls(scope: ScanScope): EventEmission[] {
+  const emissions: EventEmission[] = [];
+  const sanitized = sanitizeCode(scope.code);
+  const publishPattern =
+    /\b[A-Za-z_][A-Za-z0-9_]*\s*\.\s*events\s*\(\s*\)\s*\.\s*publish\s*\(/g;
+
+  for (const match of sanitized.matchAll(publishPattern)) {
+    const openParen = (match.index ?? 0) + match[0].lastIndexOf('(');
+    const closeParen = findMatching(sanitized, openParen, '(', ')');
+    if (closeParen === -1) continue;
+
+    const args = scope.code.slice(openParen + 1, closeParen);
+    const source = scope.code.slice(match.index ?? 0, closeParen + 1);
+
+    emissions.push({
+      key: `soroban-publish:${normalizeExpression(args)}`,
+      line: scope.startLine + lineAt(match.index ?? 0, scope.lineStarts) - 1,
+      snippet: toSnippet(source),
+    });
+  }
+
+  return emissions;
+}
+
+function extractTypedSorobanPublishCalls(scope: ScanScope): EventEmission[] {
+  const emissions: EventEmission[] = [];
+  const sanitized = sanitizeCode(scope.code);
+  const publishPattern = /\b([A-Z][A-Za-z0-9_]*)\s*\{/g;
+
+  for (const match of sanitized.matchAll(publishPattern)) {
+    const objectOpen = (match.index ?? 0) + match[0].lastIndexOf('{');
+    const objectClose = findMatching(sanitized, objectOpen, '{', '}');
+    if (objectClose === -1) continue;
+
+    const afterObject = sanitized.slice(objectClose + 1);
+    const publishMatch = afterObject.match(/^\s*\.\s*publish\s*\(/);
+    if (!publishMatch) continue;
+
+    const publishOpen = objectClose + 1 + publishMatch[0].lastIndexOf('(');
+    const publishClose = findMatching(sanitized, publishOpen, '(', ')');
+    if (publishClose === -1) continue;
+
+    const eventName = match[1];
+    const fields = scope.code.slice(objectOpen + 1, objectClose);
+    const publishArgs = scope.code.slice(publishOpen + 1, publishClose);
+    const source = scope.code.slice(match.index ?? 0, publishClose + 1);
+
+    emissions.push({
+      key: `soroban-typed:${eventName}:${normalizeExpression(fields)}:${normalizeExpression(publishArgs)}`,
+      line: scope.startLine + lineAt(match.index ?? 0, scope.lineStarts) - 1,
+      snippet: toSnippet(source),
+    });
+  }
+
+  return emissions;
+}
+
+function groupByEventKey(emissions: EventEmission[]): Map<string, EventEmission[]> {
+  const grouped = new Map<string, EventEmission[]>();
+
+  for (const emission of emissions) {
+    const existing = grouped.get(emission.key);
+    if (existing) {
+      existing.push(emission);
+    } else {
+      grouped.set(emission.key, [emission]);
+    }
+  }
+
+  return grouped;
+}
+
+function sanitizeCode(code: string): string {
+  let result = '';
+  let i = 0;
+
+  while (i < code.length) {
+    const char = code[i];
+    const next = code[i + 1];
+
+    if (char === '/' && next === '/') {
+      result += '  ';
+      i += 2;
+      while (i < code.length && code[i] !== '\n') {
+        result += ' ';
+        i++;
+      }
+      continue;
+    }
+
+    if (char === '/' && next === '*') {
+      result += '  ';
+      i += 2;
+      while (i < code.length && !(code[i] === '*' && code[i + 1] === '/')) {
+        result += code[i] === '\n' ? '\n' : ' ';
+        i++;
+      }
+      if (i < code.length) {
+        result += '  ';
+        i += 2;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === '`') {
+      const quote = char;
+      result += quote;
+      i++;
+      while (i < code.length) {
+        if (code[i] === '\\') {
+          result += '  ';
+          i += 2;
+          continue;
+        }
+        if (code[i] === quote) {
+          result += quote;
+          i++;
+          break;
+        }
+        result += code[i] === '\n' ? '\n' : ' ';
+        i++;
+      }
+      continue;
+    }
+
+    result += char;
+    i++;
+  }
+
+  return result;
+}
+
+function findMatching(code: string, openIndex: number, open: string, close: string): number {
+  let depth = 0;
+
+  for (let i = openIndex; i < code.length; i++) {
+    if (code[i] === open) depth++;
+    if (code[i] === close) {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+
+  return -1;
+}
+
+function normalizeExpression(expression: string): string {
+  return stripComments(expression)
+    .replace(/\s+/g, '')
+    .replace(/,\)/g, ')')
+    .trim();
+}
+
+function stripComments(code: string): string {
+  let result = '';
+  let i = 0;
+
+  while (i < code.length) {
+    const char = code[i];
+    const next = code[i + 1];
+
+    if (char === '/' && next === '/') {
+      i += 2;
+      while (i < code.length && code[i] !== '\n') i++;
+      continue;
+    }
+
+    if (char === '/' && next === '*') {
+      i += 2;
+      while (i < code.length && !(code[i] === '*' && code[i + 1] === '/')) i++;
+      if (i < code.length) i += 2;
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === '`') {
+      const quote = char;
+      result += quote;
+      i++;
+      while (i < code.length) {
+        result += code[i];
+        if (code[i] === '\\') {
+          i++;
+          if (i < code.length) result += code[i];
+        } else if (code[i] === quote) {
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+
+    result += char;
+    i++;
+  }
+
+  return result;
+}
+
+function buildLineStarts(code: string): number[] {
+  const starts = [0];
+
+  for (let i = 0; i < code.length; i++) {
+    if (code[i] === '\n') starts.push(i + 1);
+  }
+
+  return starts;
+}
+
+function lineAt(index: number, lineStarts: number[]): number {
+  let low = 0;
+  let high = lineStarts.length - 1;
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    if (lineStarts[mid] <= index) {
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  return high + 1;
+}
+
+function toSnippet(source: string): string {
+  const compact = source.replace(/\s+/g, ' ').trim();
+  return compact.length > MAX_SNIPPET_LENGTH
+    ? `${compact.slice(0, MAX_SNIPPET_LENGTH - 3)}...`
+    : compact;
+}

--- a/tests/rules/detect-duplicate-event-emissions.spec.ts
+++ b/tests/rules/detect-duplicate-event-emissions.spec.ts
@@ -1,0 +1,171 @@
+import { detectDuplicateEventEmissions } from '../../rules/auditability/events/detect-duplicate-event-emissions';
+import { GasGuardEngine } from '../../packages/rules/gasGuard/gasguard.engine';
+
+describe('detectDuplicateEventEmissions', () => {
+  it('detects duplicate Solidity event emissions in the same function', () => {
+    const code = `
+      function transfer(address to, uint256 amount) external {
+        emit Transfer(msg.sender, to, amount);
+        emit Transfer(msg.sender, to, amount);
+      }
+    `;
+
+    const result = detectDuplicateEventEmissions(code);
+
+    expect(result.detected).toBe(true);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].count).toBe(2);
+    expect(result.suggestion).toMatch(/Consolidate/);
+  });
+
+  it('detects duplicate Solidity event emissions in constructors', () => {
+    const code = `
+      constructor(address owner) {
+        emit OwnerSet(owner);
+        emit OwnerSet(owner);
+      }
+    `;
+
+    const result = detectDuplicateEventEmissions(code);
+
+    expect(result.detected).toBe(true);
+    expect(result.violations).toHaveLength(1);
+  });
+
+  it('detects duplicate Soroban env.events publish calls', () => {
+    const code = `
+      pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        env.events().publish((symbol_short!("transfer"), from.clone(), to.clone()), amount);
+        env.events().publish((symbol_short!("transfer"), from.clone(), to.clone()), amount);
+      }
+    `;
+
+    const result = detectDuplicateEventEmissions(code);
+
+    expect(result.detected).toBe(true);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].duplicateLines.length).toBe(1);
+  });
+
+  it('detects duplicate Soroban publish calls when Env has a custom variable name', () => {
+    const code = `
+      pub fn transfer(e: Env, amount: i128) {
+        e.events().publish((symbol_short!("transfer"),), amount);
+        e.events().publish((symbol_short!("transfer"),), amount);
+      }
+    `;
+
+    const result = detectDuplicateEventEmissions(code);
+
+    expect(result.detected).toBe(true);
+    expect(result.violations).toHaveLength(1);
+  });
+
+  it('detects duplicate typed Soroban event publish calls', () => {
+    const code = `
+      pub fn increment(env: Env, count: u32) {
+        IncrementEvent { count }.publish(&env);
+        IncrementEvent { count }.publish(&env);
+      }
+    `;
+
+    const result = detectDuplicateEventEmissions(code);
+
+    expect(result.detected).toBe(true);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].eventKey).toContain('IncrementEvent');
+  });
+
+  it('does not flag different event payloads', () => {
+    const code = `
+      pub fn update(env: Env, old_value: u32, new_value: u32) {
+        env.events().publish((symbol_short!("update"),), old_value);
+        env.events().publish((symbol_short!("update"),), new_value);
+      }
+    `;
+
+    const result = detectDuplicateEventEmissions(code);
+
+    expect(result.detected).toBe(false);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('does not compare event emissions across separate functions', () => {
+    const code = `
+      function a(address user) external {
+        emit Updated(user);
+      }
+
+      function b(address user) external {
+        emit Updated(user);
+      }
+    `;
+
+    const result = detectDuplicateEventEmissions(code);
+
+    expect(result.detected).toBe(false);
+  });
+
+  it('does not compare event emissions across separate Rust methods', () => {
+    const code = `
+      impl Token {
+        pub fn mint(env: Env, user: Address, amount: i128) {
+          env.events().publish((symbol_short!("transfer"), user.clone()), amount);
+        }
+
+        pub fn burn(env: Env, user: Address, amount: i128) {
+          env.events().publish((symbol_short!("transfer"), user.clone()), amount);
+        }
+      }
+    `;
+
+    const result = detectDuplicateEventEmissions(code);
+
+    expect(result.detected).toBe(false);
+  });
+
+  it('does not collapse different string literal topics', () => {
+    const code = `
+      pub fn update(env: Env, amount: i128) {
+        env.events().publish((symbol_short!("mint"),), amount);
+        env.events().publish((symbol_short!("burn"),), amount);
+      }
+    `;
+
+    const result = detectDuplicateEventEmissions(code);
+
+    expect(result.detected).toBe(false);
+  });
+
+  it('ignores commented out duplicate emissions', () => {
+    const code = `
+      function transfer(address to, uint256 amount) external {
+        emit Transfer(msg.sender, to, amount);
+        // emit Transfer(msg.sender, to, amount);
+      }
+    `;
+
+    const result = detectDuplicateEventEmissions(code);
+
+    expect(result.detected).toBe(false);
+  });
+
+  it('surfaces duplicate Soroban events through the GasGuard engine', async () => {
+    const engine = new GasGuardEngine();
+    const result = await engine.scan({
+      language: 'soroban',
+      source: `
+        pub fn transfer(env: Env, amount: i128) {
+          env.events().publish((symbol_short!("transfer"),), amount);
+          env.events().publish((symbol_short!("transfer"),), amount);
+        }
+      `,
+    });
+
+    expect(
+      result.issues.some(
+        (issue) => issue.ruleId === 'detect-duplicate-event-emissions',
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #321 

# PR Description

This PR Closes issue #321 by adding an auditability rule that detects repeated event emissions inside the same function scope and reports them with a consolidation suggestion.

Before this change, GasGuard did not have a rule under `rules/auditability/events/` for redundant event emissions. Duplicate events can waste gas and add unnecessary log noise because the same event payload is published more than once for the same operation.

The new detector scans function-level scopes and groups event emissions by a normalized event signature. If the same event name, topics, data, and publish arguments appear more than once in the same scope, the detector reports a duplicate event pattern. The result includes the first emission line, duplicate lines, snippets, and a suggestion to consolidate repeated event emissions into one publish or emit call after the state change has completed.

The rule supports Solidity `emit EventName(...)`, Solidity constructor/fallback/receive scopes, Soroban `Env.events().publish(...)` calls with any Env variable name, and typed Soroban event publishing such as `IncrementEvent { count }.publish(&env)`. Comments are ignored during structural scanning, while string literal topics are preserved during signature normalization so different topics are not collapsed into a false duplicate.

The detector is wired into the existing GasGuard Soroban and Solidity analyzer paths so duplicate event issues are surfaced during scans, not only through direct rule imports.

# Changes Made

- Added the duplicate event emission detector for #321 in `rules/auditability/events/detect-duplicate-event-emissions.ts`.
- Added detection for Solidity `emit EventName(...)` calls.
- Added detection for Solidity constructor, fallback, and receive scopes.
- Added detection for Soroban `Env.events().publish(topics, data)` calls with any Env variable name.
- Added detection for typed Soroban event publishes such as `IncrementEvent { count }.publish(&env)`.
- Added normalized event signatures so duplicate event names, topics, data, and publish arguments are grouped per function scope.
- Added comment sanitization so commented-out duplicate examples are not reported.
- Preserved string literal topics during normalization so different event topics are treated as distinct.
- Added line tracking for first and duplicate event emission locations.
- Wired the detector into `packages/rules/gasGuard/src/languages/soroban.analyzer.ts`.
- Wired the detector into `packages/rules/gasGuard/src/languages/solidity.analyzer.ts`.
- Added focused tests in `tests/rules/detect-duplicate-event-emissions.spec.ts`.

# Scope Notes

- Production rule and analyzer integration change.
- No frontend changes.
- No backend API changes.
- No contract logic changes.
- No dependency changes.
- No snapshot files staged or committed.