### PR TITLE
feat: Detect Unnecessary Public Functions & Constructor Visibility Issues

### DIFF
--- a/packages/rules/src/optimization/mod.rs
+++ b/packages/rules/src/optimization/mod.rs
@@ -1,6 +1,7 @@
 pub mod deployment;
 pub mod encoding;
 pub mod storage;
+pub mod visibility;
 
 pub use storage::{
     detect_packing_opportunities, find_consecutive_packable_groups, get_type_size,
@@ -9,3 +10,4 @@ pub use storage::{
 
 pub use deployment::{estimate_bytecode_size, ExcessiveContractSizeRule};
 pub use encoding::detect_abi_encoding_inefficiencies;
+pub use visibility::{check_unnecessary_public_functions, UnnecessaryPublicFunctionRule};

--- a/packages/rules/src/optimization/visibility/mod.rs
+++ b/packages/rules/src/optimization/visibility/mod.rs
@@ -1,0 +1,5 @@
+pub mod unnecessary_public_functions;
+
+pub use unnecessary_public_functions::{
+    check_unnecessary_public_functions, UnnecessaryPublicFunctionRule,
+};

--- a/packages/rules/src/optimization/visibility/unnecessary_public_functions.rs
+++ b/packages/rules/src/optimization/visibility/unnecessary_public_functions.rs
@@ -1,0 +1,155 @@
+//! Detect Unnecessary Public Functions (#338)
+//!
+//! Flags Solidity `public` functions that are never called internally within
+//! the same contract. Changing them to `external` allows the EVM to read
+//! arguments directly from calldata instead of copying to memory, saving gas.
+
+use crate::rule_engine::{Rule, RuleViolation, ViolationSeverity};
+use syn::Item;
+
+pub struct UnnecessaryPublicFunctionRule;
+
+impl UnnecessaryPublicFunctionRule {
+    /// Extract all `public` function names from a Solidity-like token stream.
+    fn public_function_names(code: &str) -> Vec<(String, usize)> {
+        let mut result = Vec::new();
+        // Simple line-by-line scan for `function <name>(...) ... public`
+        for (i, line) in code.lines().enumerate() {
+            if line.contains("function") && line.contains("public") {
+                if let Some(name) = Self::extract_function_name(line) {
+                    result.push((name, i + 1));
+                }
+            }
+        }
+        result
+    }
+
+    fn extract_function_name(line: &str) -> Option<String> {
+        let after = line.find("function")? + "function".len();
+        let rest = line[after..].trim_start();
+        let end = rest.find(|c: char| !c.is_alphanumeric() && c != '_')?;
+        if end == 0 {
+            return None;
+        }
+        Some(rest[..end].to_string())
+    }
+
+    /// Return true if `name` is called somewhere in `code` other than its own
+    /// declaration line.
+    fn is_called_internally(name: &str, code: &str, decl_line: usize) -> bool {
+        let call_pattern = format!("{}(", name);
+        for (i, line) in code.lines().enumerate() {
+            let lineno = i + 1;
+            if lineno == decl_line {
+                continue;
+            }
+            if line.contains(&call_pattern) {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+impl Rule for UnnecessaryPublicFunctionRule {
+    fn name(&self) -> &str {
+        "unnecessary-public-function"
+    }
+
+    fn description(&self) -> &str {
+        "Detects public functions that are never called internally. \
+         Changing them to `external` saves gas because arguments are read \
+         directly from calldata instead of being copied to memory."
+    }
+
+    fn check(&self, ast: &[Item]) -> Vec<RuleViolation> {
+        let mut violations = Vec::new();
+
+        for item in ast {
+            let code = format!("{:?}", item);
+            let functions = Self::public_function_names(&code);
+
+            for (name, line) in functions {
+                if !Self::is_called_internally(&name, &code, line) {
+                    violations.push(RuleViolation {
+                        rule_name: self.name().to_string(),
+                        description: format!(
+                            "Function `{}` is declared `public` but is never called \
+                             internally — it can be changed to `external`.",
+                            name
+                        ),
+                        severity: ViolationSeverity::Low,
+                        line_number: line,
+                        column_number: 0,
+                        variable_name: name.clone(),
+                        suggestion: format!(
+                            "Replace `public` with `external` on `{}`. \
+                             External functions read calldata directly, avoiding \
+                             the memory-copy overhead of `public`.",
+                            name
+                        ),
+                    });
+                }
+            }
+        }
+
+        violations
+    }
+}
+
+/// Standalone checker that works on raw Solidity source (not a Rust AST).
+pub fn check_unnecessary_public_functions(source: &str) -> Vec<(String, usize)> {
+    let mut flagged = Vec::new();
+    let functions = UnnecessaryPublicFunctionRule::public_function_names(source);
+    for (name, line) in functions {
+        if !UnnecessaryPublicFunctionRule::is_called_internally(&name, source, line) {
+            flagged.push((name, line));
+        }
+    }
+    flagged
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flags_public_only_called_externally() {
+        let src = r#"
+            contract Token {
+                function transfer(address to, uint256 amount) public returns (bool) {
+                    return true;
+                }
+            }
+        "#;
+        let result = check_unnecessary_public_functions(src);
+        assert!(!result.is_empty(), "should flag transfer as unnecessarily public");
+        assert_eq!(result[0].0, "transfer");
+    }
+
+    #[test]
+    fn does_not_flag_internally_called_public_fn() {
+        let src = r#"
+            contract Token {
+                function transfer(address to, uint256 amount) public returns (bool) {
+                    return _transfer(to, amount);
+                }
+                function batchTransfer(address[] memory to, uint256 amount) public {
+                    for (uint i = 0; i < to.length; i++) {
+                        transfer(to[i], amount);
+                    }
+                }
+            }
+        "#;
+        let result = check_unnecessary_public_functions(src);
+        // `transfer` is called internally by `batchTransfer`, so only
+        // `batchTransfer` (if not called internally) should be flagged.
+        let names: Vec<&str> = result.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(!names.contains(&"transfer"), "transfer is called internally");
+    }
+
+    #[test]
+    fn empty_source_produces_no_violations() {
+        assert!(check_unnecessary_public_functions("").is_empty());
+    }
+}

--- a/packages/rules/src/security/constructors/constructor_visibility.rs
+++ b/packages/rules/src/security/constructors/constructor_visibility.rs
@@ -1,0 +1,220 @@
+//! Detect Constructor Visibility Issues (#337)
+//!
+//! Solidity ≥ 0.7.0 removed visibility modifiers (`public` / `internal`) on
+//! constructors. Their presence is a compile error. In earlier versions the
+//! modifiers were redundant (`public`) or used to mark abstract contracts
+//! (`internal`). This rule flags both patterns and suggests the correct fix.
+
+use crate::rule_engine::{Rule, RuleViolation, ViolationSeverity};
+use syn::Item;
+
+pub struct ConstructorVisibilityRule;
+
+#[derive(Debug, PartialEq)]
+enum CtorKind {
+    ModernPublic,
+    ModernInternal,
+    LegacyPublic,
+    LegacyInternal,
+}
+
+impl ConstructorVisibilityRule {
+    fn scan(source: &str) -> Vec<(CtorKind, usize, String)> {
+        let mut findings = Vec::new();
+
+        // Collect contract names for legacy constructor detection.
+        let mut contract_names: Vec<String> = Vec::new();
+        for line in source.lines() {
+            let trimmed = line.trim();
+            if trimmed.starts_with("contract ") || trimmed.contains(" contract ") {
+                if let Some(name) = Self::extract_word_after(trimmed, "contract") {
+                    contract_names.push(name);
+                }
+            }
+        }
+
+        for (i, line) in source.lines().enumerate() {
+            let lineno = i + 1;
+            let trimmed = line.trim();
+
+            // Modern constructor: `constructor(...)` with visibility modifier
+            if trimmed.starts_with("constructor") {
+                if Self::contains_word(trimmed, "public") {
+                    findings.push((CtorKind::ModernPublic, lineno, trimmed.to_string()));
+                } else if Self::contains_word(trimmed, "internal") {
+                    findings.push((CtorKind::ModernInternal, lineno, trimmed.to_string()));
+                }
+            }
+
+            // Legacy constructor: `function <ContractName>(...)`
+            for name in &contract_names {
+                let legacy_sig = format!("function {}(", name);
+                if trimmed.contains(&legacy_sig) || trimmed.contains(&format!("function {} (", name)) {
+                    if Self::contains_word(trimmed, "public") {
+                        findings.push((CtorKind::LegacyPublic, lineno, trimmed.to_string()));
+                    } else if Self::contains_word(trimmed, "internal") {
+                        findings.push((CtorKind::LegacyInternal, lineno, trimmed.to_string()));
+                    }
+                }
+            }
+        }
+
+        findings
+    }
+
+    fn contains_word(s: &str, word: &str) -> bool {
+        let pat = format!(r"\b{}\b", word);
+        // Simple word-boundary check without regex crate dependency.
+        if let Some(idx) = s.find(word) {
+            let before = idx == 0 || !s.as_bytes()[idx - 1].is_ascii_alphanumeric();
+            let after_idx = idx + word.len();
+            let after = after_idx >= s.len() || !s.as_bytes()[after_idx].is_ascii_alphanumeric();
+            before && after
+        } else {
+            let _ = pat; // suppress unused warning
+            false
+        }
+    }
+
+    fn extract_word_after(s: &str, keyword: &str) -> Option<String> {
+        let idx = s.find(keyword)? + keyword.len();
+        let rest = s[idx..].trim_start();
+        let end = rest.find(|c: char| !c.is_alphanumeric() && c != '_')?;
+        if end == 0 {
+            return None;
+        }
+        Some(rest[..end].to_string())
+    }
+}
+
+impl Rule for ConstructorVisibilityRule {
+    fn name(&self) -> &str {
+        "constructor-visibility"
+    }
+
+    fn description(&self) -> &str {
+        "Detects constructors with visibility modifiers (`public` or `internal`). \
+         These modifiers are a compile error in Solidity ≥ 0.7.0. \
+         For abstract contracts use the `abstract` keyword instead."
+    }
+
+    fn check(&self, ast: &[Item]) -> Vec<RuleViolation> {
+        let mut violations = Vec::new();
+
+        for item in ast {
+            let code = format!("{:?}", item);
+            let findings = Self::scan(&code);
+
+            for (kind, line, snippet) in findings {
+                let (description, suggestion, severity) = match kind {
+                    CtorKind::ModernPublic => (
+                        "Constructor declares `public` visibility — redundant and illegal in Solidity ≥ 0.7.0.".to_string(),
+                        "Remove the `public` modifier from the constructor.".to_string(),
+                        ViolationSeverity::Medium,
+                    ),
+                    CtorKind::ModernInternal => (
+                        "Constructor declares `internal` visibility — illegal in Solidity ≥ 0.7.0.".to_string(),
+                        "Remove `internal` and declare the contract `abstract` instead.".to_string(),
+                        ViolationSeverity::High,
+                    ),
+                    CtorKind::LegacyPublic => (
+                        "Legacy function-style constructor with `public` modifier is outdated.".to_string(),
+                        "Migrate to `constructor(...)` syntax and remove the visibility modifier.".to_string(),
+                        ViolationSeverity::Medium,
+                    ),
+                    CtorKind::LegacyInternal => (
+                        "Legacy function-style constructor with `internal` modifier is outdated.".to_string(),
+                        "Migrate to `abstract contract` with `constructor(...)` syntax.".to_string(),
+                        ViolationSeverity::High,
+                    ),
+                };
+
+                violations.push(RuleViolation {
+                    rule_name: self.name().to_string(),
+                    description,
+                    severity,
+                    line_number: line,
+                    column_number: 0,
+                    variable_name: snippet,
+                    suggestion,
+                });
+            }
+        }
+
+        violations
+    }
+}
+
+/// Standalone checker that works on raw Solidity source strings.
+pub fn check_constructor_visibility(source: &str) -> Vec<(String, usize)> {
+    ConstructorVisibilityRule::scan(source)
+        .into_iter()
+        .map(|(kind, line, _snippet)| {
+            let label = match kind {
+                CtorKind::ModernPublic => "constructor-public",
+                CtorKind::ModernInternal => "constructor-internal",
+                CtorKind::LegacyPublic => "legacy-constructor-public",
+                CtorKind::LegacyInternal => "legacy-constructor-internal",
+            };
+            (label.to_string(), line)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flags_public_constructor() {
+        let src = r#"
+            contract Token {
+                constructor(uint256 supply) public {
+                    totalSupply = supply;
+                }
+            }
+        "#;
+        let result = check_constructor_visibility(src);
+        assert!(!result.is_empty());
+        assert_eq!(result[0].0, "constructor-public");
+    }
+
+    #[test]
+    fn flags_internal_constructor() {
+        let src = r#"
+            contract Base {
+                constructor() internal {}
+            }
+        "#;
+        let result = check_constructor_visibility(src);
+        assert!(!result.is_empty());
+        assert_eq!(result[0].0, "constructor-internal");
+    }
+
+    #[test]
+    fn flags_legacy_public_constructor() {
+        let src = r#"
+            contract OldToken {
+                function OldToken(uint256 supply) public {
+                    totalSupply = supply;
+                }
+            }
+        "#;
+        let result = check_constructor_visibility(src);
+        assert!(!result.is_empty());
+        assert_eq!(result[0].0, "legacy-constructor-public");
+    }
+
+    #[test]
+    fn clean_constructor_no_violation() {
+        let src = r#"
+            contract Modern {
+                constructor(uint256 supply) {
+                    totalSupply = supply;
+                }
+            }
+        "#;
+        let result = check_constructor_visibility(src);
+        assert!(result.is_empty());
+    }
+}

--- a/packages/rules/src/security/constructors/mod.rs
+++ b/packages/rules/src/security/constructors/mod.rs
@@ -1,0 +1,3 @@
+pub mod constructor_visibility;
+
+pub use constructor_visibility::{check_constructor_visibility, ConstructorVisibilityRule};

--- a/packages/rules/src/security/mod.rs
+++ b/packages/rules/src/security/mod.rs
@@ -1,9 +1,11 @@
 pub mod configuration;
+pub mod constructors;
 pub mod signatures;
 pub mod emergency;
 pub mod defi;
 
 pub use configuration::HardcodedAddressesRule;
+pub use constructors::{check_constructor_visibility, ConstructorVisibilityRule};
 pub use signatures::MissingDomainSeparationRule;
 pub use emergency::MissingCircuitBreakerRule;
 pub use defi::MissingSlippageValidationRule;

--- a/rules/optimization/visibility/detect-unnecessary-public-functions.ts
+++ b/rules/optimization/visibility/detect-unnecessary-public-functions.ts
@@ -1,0 +1,109 @@
+/**
+ * Detect Unnecessary Public Functions (#338)
+ *
+ * Flags `public` functions in Solidity contracts that are only ever called
+ * externally (i.e. never called internally by the same contract). Declaring
+ * such functions as `external` is cheaper: external functions read their
+ * arguments directly from calldata instead of copying them to memory, which
+ * saves gas on every invocation.
+ *
+ * Detection strategy:
+ *  1. Collect every `public` function name and full signature span.
+ *  2. Remove the entire function signature from the source before searching
+ *     for internal call sites (prevents the parameter list from matching).
+ *  3. If the function name does not appear anywhere in the remaining source,
+ *     it is never called internally and should be `external`.
+ *
+ * Limitations: purely regex-based — does not resolve inheritance or libraries.
+ */
+
+export interface PublicFunctionViolation {
+  functionName: string;
+  line: number;
+  suggestion: string;
+}
+
+export interface UnnecessaryPublicResult {
+  detected: boolean;
+  violations: PublicFunctionViolation[];
+  functionsScanned: number;
+  message: string;
+  suggestion: string;
+}
+
+// Matches `function <name>(...) public ...`
+// Captures group 1 = function name
+const PUBLIC_FN_RE =
+  /\bfunction\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*\([^)]*\)[^{;]*\bpublic\b/g;
+
+function lineAt(code: string, offset: number): number {
+  let line = 1;
+  for (let i = 0; i < offset; i++) {
+    if (code[i] === '\n') line++;
+  }
+  return line;
+}
+
+export function detectUnnecessaryPublicFunctions(
+  code: string,
+): UnnecessaryPublicResult {
+  const violations: PublicFunctionViolation[] = [];
+  let functionsScanned = 0;
+
+  // Remove single-line and multi-line comments to avoid false matches.
+  const stripped = code
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+
+  const matches: Array<{ name: string; index: number; matchLen: number }> = [];
+  let m: RegExpExecArray | null;
+  PUBLIC_FN_RE.lastIndex = 0;
+  while ((m = PUBLIC_FN_RE.exec(stripped)) !== null) {
+    matches.push({ name: m[1], index: m.index, matchLen: m[0].length });
+  }
+
+  functionsScanned = matches.length;
+
+  for (const { name, index, matchLen } of matches) {
+    // Remove the entire declaration (signature line) so the function name
+    // inside its own parameter list does not count as an internal call site.
+    const withoutDecl =
+      stripped.slice(0, index) + stripped.slice(index + matchLen);
+
+    // An internal call looks like `name(` — possibly preceded by whitespace,
+    // a dot (super.name), `this.name`, or the start of a statement.
+    const callRe = new RegExp(`\\b${name}\\s*\\(`, 'g');
+    const calledInternally = callRe.test(withoutDecl);
+
+    if (!calledInternally) {
+      violations.push({
+        functionName: name,
+        line: lineAt(code, index),
+        suggestion: `Change \`public\` to \`external\` on \`${name}\` — it is never called internally and \`external\` reads arguments directly from calldata, saving gas.`,
+      });
+    }
+  }
+
+  if (violations.length === 0) {
+    return {
+      detected: false,
+      violations: [],
+      functionsScanned,
+      message:
+        functionsScanned === 0
+          ? 'No public functions found.'
+          : 'All public functions are called internally; no visibility change needed.',
+      suggestion: '',
+    };
+  }
+
+  const names = violations.map((v) => v.functionName).join(', ');
+  return {
+    detected: true,
+    violations,
+    functionsScanned,
+    message: `${violations.length} public function(s) are only called externally and should be \`external\`: ${names}.`,
+    suggestion:
+      'Replace `public` with `external` on functions that are never invoked from within the contract. `external` functions pass arguments via calldata (no memory copy), reducing gas costs.',
+  };
+}

--- a/rules/security/constructors/detect-constructor-visibility.ts
+++ b/rules/security/constructors/detect-constructor-visibility.ts
@@ -1,0 +1,168 @@
+/**
+ * Detect Constructor Visibility Issues (#337)
+ *
+ * Solidity ≥ 0.7.0 removed constructor visibility modifiers (`public` /
+ * `internal`). Using them in modern code causes a compilation error. In older
+ * code (< 0.7.0) using `internal` on the constructor was the correct way to
+ * mark a contract as abstract; using `public` was redundant because
+ * constructors are always public by default.
+ *
+ * This rule flags:
+ *  1. `constructor(...) public`  — redundant; `public` on a constructor has
+ *     no effect and is rejected by Solidity ≥ 0.7.
+ *  2. `constructor(...) internal` — valid only in Solidity < 0.7 to make the
+ *     contract abstract; still confusing and unsupported in modern Solidity.
+ *  3. Legacy `function ContractName(...)` constructors (Solidity < 0.4.22)
+ *     that carry an explicit `public` or `internal` modifier — these are
+ *     almost certainly stale patterns.
+ *
+ * Solidity pragma is extracted to give context-aware suggestions.
+ */
+
+export type ConstructorVisibilityKind =
+  | 'constructor-public'
+  | 'constructor-internal'
+  | 'legacy-constructor-public'
+  | 'legacy-constructor-internal';
+
+export interface ConstructorViolation {
+  kind: ConstructorVisibilityKind;
+  line: number;
+  snippet: string;
+  reason: string;
+  fix: string;
+}
+
+export interface ConstructorVisibilityResult {
+  detected: boolean;
+  violations: ConstructorViolation[];
+  solcVersion: string | null;
+  message: string;
+  suggestion: string;
+}
+
+// Matches `constructor ( ... ) [modifiers including public/internal]`
+const CONSTRUCTOR_RE =
+  /\bconstructor\s*\([^)]*\)[^{;]*?\b(public|internal)\b[^{;]*/g;
+
+// Matches legacy `function <ContractName>(...) public/internal`
+// We detect this by looking for a `contract Name` and then a `function Name(`
+const CONTRACT_NAME_RE = /\bcontract\s+([A-Za-z_$][A-Za-z0-9_$]*)/g;
+
+const PRAGMA_RE = /pragma\s+solidity\s+([^;]+);/;
+
+const REASON_MAP: Record<ConstructorVisibilityKind, string> = {
+  'constructor-public':
+    '`public` on a constructor is redundant (constructors are always public) and a compile error in Solidity ≥ 0.7.0',
+  'constructor-internal':
+    '`internal` on a constructor is not valid in Solidity ≥ 0.7.0; use `abstract contract` instead',
+  'legacy-constructor-public':
+    'Legacy function-style constructor with `public` modifier is outdated; use the `constructor` keyword',
+  'legacy-constructor-internal':
+    'Legacy function-style constructor with `internal` modifier is outdated; use `abstract contract` with the `constructor` keyword',
+};
+
+const FIX_MAP: Record<ConstructorVisibilityKind, string> = {
+  'constructor-public': 'Remove the `public` modifier from the constructor.',
+  'constructor-internal':
+    'Remove the `internal` modifier and declare the contract as `abstract contract`.',
+  'legacy-constructor-public':
+    'Replace the function-style constructor with `constructor(...)` and remove `public`.',
+  'legacy-constructor-internal':
+    'Replace the function-style constructor with `constructor(...)`, declare the contract `abstract`, and remove `internal`.',
+};
+
+function lineAt(code: string, offset: number): number {
+  let line = 1;
+  for (let i = 0; i < offset; i++) {
+    if (code[i] === '\n') line++;
+  }
+  return line;
+}
+
+function extractSolcVersion(code: string): string | null {
+  const m = PRAGMA_RE.exec(code);
+  return m ? m[1].trim() : null;
+}
+
+function stripComments(code: string): string {
+  return code
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+export function detectConstructorVisibility(
+  code: string,
+): ConstructorVisibilityResult {
+  const violations: ConstructorViolation[] = [];
+  const stripped = stripComments(code);
+  const solcVersion = extractSolcVersion(stripped);
+
+  // 1. Modern `constructor` keyword with visibility modifier
+  let m: RegExpExecArray | null;
+  CONSTRUCTOR_RE.lastIndex = 0;
+  while ((m = CONSTRUCTOR_RE.exec(stripped)) !== null) {
+    const modifier = m[1] as 'public' | 'internal';
+    const kind: ConstructorVisibilityKind =
+      modifier === 'public' ? 'constructor-public' : 'constructor-internal';
+    const snippet = m[0].trim().split('\n')[0].trim();
+    violations.push({
+      kind,
+      line: lineAt(code, m.index),
+      snippet,
+      reason: REASON_MAP[kind],
+      fix: FIX_MAP[kind],
+    });
+  }
+
+  // 2. Legacy function-style constructors: `function ContractName(`
+  CONTRACT_NAME_RE.lastIndex = 0;
+  let contractMatch: RegExpExecArray | null;
+  while ((contractMatch = CONTRACT_NAME_RE.exec(stripped)) !== null) {
+    const contractName = contractMatch[1];
+    // Escape the name for use in a regex
+    const legacyRe = new RegExp(
+      `\\bfunction\\s+${contractName}\\s*\\([^)]*\\)[^{;]*?\\b(public|internal)\\b`,
+      'g',
+    );
+    let legacyMatch: RegExpExecArray | null;
+    while ((legacyMatch = legacyRe.exec(stripped)) !== null) {
+      const modifier = legacyMatch[1] as 'public' | 'internal';
+      const kind: ConstructorVisibilityKind =
+        modifier === 'public'
+          ? 'legacy-constructor-public'
+          : 'legacy-constructor-internal';
+      const snippet = legacyMatch[0].trim().split('\n')[0].trim();
+      violations.push({
+        kind,
+        line: lineAt(code, legacyMatch.index),
+        snippet,
+        reason: REASON_MAP[kind],
+        fix: FIX_MAP[kind],
+      });
+    }
+  }
+
+  if (violations.length === 0) {
+    return {
+      detected: false,
+      violations: [],
+      solcVersion,
+      message: 'No constructor visibility issues detected.',
+      suggestion: '',
+    };
+  }
+
+  const summary = violations
+    .map((v) => `line ${v.line}: ${v.kind}`)
+    .join('; ');
+
+  return {
+    detected: true,
+    violations,
+    solcVersion,
+    message: `${violations.length} constructor visibility issue(s) detected: ${summary}.`,
+    suggestion:
+      'Remove visibility modifiers from constructors. In Solidity ≥ 0.7.0 they are illegal. For abstract contracts use `abstract contract`. For legacy code migrate to the `constructor` keyword.',
+  };
+}

--- a/tests/rules/detect-constructor-visibility.spec.ts
+++ b/tests/rules/detect-constructor-visibility.spec.ts
@@ -1,0 +1,88 @@
+import { detectConstructorVisibility } from '../../rules/security/constructors/detect-constructor-visibility';
+
+describe('detectConstructorVisibility', () => {
+  it('flags a constructor with public modifier', () => {
+    const code = `
+      pragma solidity ^0.8.0;
+      contract Token {
+        constructor(uint256 supply) public {
+          totalSupply = supply;
+        }
+      }
+    `;
+    const result = detectConstructorVisibility(code);
+    expect(result.detected).toBe(true);
+    expect(result.violations.length).toBe(1);
+    expect(result.violations[0].kind).toBe('constructor-public');
+    expect(result.violations[0].fix).toContain('Remove');
+  });
+
+  it('flags a constructor with internal modifier', () => {
+    const code = `
+      pragma solidity ^0.6.0;
+      contract Base {
+        constructor() internal {}
+      }
+    `;
+    const result = detectConstructorVisibility(code);
+    expect(result.detected).toBe(true);
+    expect(result.violations[0].kind).toBe('constructor-internal');
+    expect(result.violations[0].fix).toContain('abstract');
+  });
+
+  it('flags a legacy function-style constructor with public', () => {
+    const code = `
+      contract OldToken {
+        function OldToken(uint256 supply) public {
+          totalSupply = supply;
+        }
+      }
+    `;
+    const result = detectConstructorVisibility(code);
+    expect(result.detected).toBe(true);
+    expect(result.violations[0].kind).toBe('legacy-constructor-public');
+  });
+
+  it('flags a legacy function-style constructor with internal', () => {
+    const code = `
+      contract OldBase {
+        function OldBase() internal {}
+      }
+    `;
+    const result = detectConstructorVisibility(code);
+    expect(result.detected).toBe(true);
+    expect(result.violations[0].kind).toBe('legacy-constructor-internal');
+  });
+
+  it('does not flag a clean modern constructor', () => {
+    const code = `
+      pragma solidity ^0.8.0;
+      contract Modern {
+        constructor(uint256 supply) {
+          totalSupply = supply;
+        }
+      }
+    `;
+    const result = detectConstructorVisibility(code);
+    expect(result.detected).toBe(false);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('extracts solc version from pragma', () => {
+    const code = `pragma solidity ^0.7.6;\ncontract C { constructor() {} }`;
+    const result = detectConstructorVisibility(code);
+    expect(result.solcVersion).toBe('^0.7.6');
+  });
+
+  it('returns null solcVersion when no pragma present', () => {
+    const code = `contract C { constructor() {} }`;
+    const result = detectConstructorVisibility(code);
+    expect(result.solcVersion).toBeNull();
+  });
+
+  it('provides a line number for each violation', () => {
+    const code = `contract C {\n  constructor() public {}\n}`;
+    const result = detectConstructorVisibility(code);
+    expect(result.violations[0].line).toBe(2);
+  });
+});

--- a/tests/rules/detect-unnecessary-public-functions.spec.ts
+++ b/tests/rules/detect-unnecessary-public-functions.spec.ts
@@ -1,0 +1,78 @@
+import { detectUnnecessaryPublicFunctions } from '../../rules/optimization/visibility/detect-unnecessary-public-functions';
+
+describe('detectUnnecessaryPublicFunctions', () => {
+  it('flags a public function never called internally', () => {
+    const code = `
+      contract Token {
+        function transfer(address to, uint256 amount) public returns (bool) {
+          return true;
+        }
+      }
+    `;
+    const result = detectUnnecessaryPublicFunctions(code);
+    expect(result.detected).toBe(true);
+    expect(result.violations.length).toBe(1);
+    expect(result.violations[0].functionName).toBe('transfer');
+    expect(result.violations[0].suggestion).toContain('external');
+  });
+
+  it('does not flag a public function that is called internally', () => {
+    const code = `
+      contract Token {
+        function transfer(address to, uint256 amount) public returns (bool) {
+          return true;
+        }
+        function batchTransfer(address[] memory to, uint256 amt) public {
+          for (uint i = 0; i < to.length; i++) {
+            transfer(to[i], amt);
+          }
+        }
+      }
+    `;
+    const result = detectUnnecessaryPublicFunctions(code);
+    // transfer is called internally, so only batchTransfer may be flagged
+    const names = result.violations.map((v) => v.functionName);
+    expect(names).not.toContain('transfer');
+  });
+
+  it('flags multiple public-only functions', () => {
+    const code = `
+      contract Multi {
+        function foo() public returns (uint) { return 1; }
+        function bar() public returns (uint) { return 2; }
+      }
+    `;
+    const result = detectUnnecessaryPublicFunctions(code);
+    expect(result.detected).toBe(true);
+    expect(result.violations.length).toBe(2);
+  });
+
+  it('returns detected=false when no public functions exist', () => {
+    const code = `
+      contract Empty {
+        function _helper() internal returns (uint) { return 0; }
+      }
+    `;
+    const result = detectUnnecessaryPublicFunctions(code);
+    expect(result.detected).toBe(false);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('provides a line number in violations', () => {
+    const code = `contract C {\n  function go() public {}\n}`;
+    const result = detectUnnecessaryPublicFunctions(code);
+    expect(result.violations[0].line).toBeGreaterThan(0);
+  });
+
+  it('reports functionsScanned count', () => {
+    const code = `
+      contract C {
+        function a() public {}
+        function b() public {}
+        function c() internal {}
+      }
+    `;
+    const result = detectUnnecessaryPublicFunctions(code);
+    expect(result.functionsScanned).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Implements two new static analysis rules for GasGuard.

---

## #338 — Detect Unnecessary Public Functions

### Problem
`public` functions in Solidity are accessible both externally and internally. When a function is only ever called from outside the contract, marking it `public` incurs unnecessary gas cost: the EVM copies calldata arguments into memory. Declaring it `external` instead reads arguments directly from calldata, saving gas on every invocation.

### Implementation
| File | Description |
|------|-------------|
| `rules/optimization/visibility/detect-unnecessary-public-functions.ts` | TypeScript rule — regex-based scan of Solidity source |
| `packages/rules/src/optimization/visibility/unnecessary_public_functions.rs` | Rust rule — implements `Rule` trait + standalone checker |
| `packages/rules/src/optimization/visibility/mod.rs` | Module wiring |
| `packages/rules/src/optimization/mod.rs` | Exports added |
| `tests/rules/detect-unnecessary-public-functions.spec.ts` | 6 tests |

### Detection Logic
1. Collect all `public` function signatures (name + full span).
2. Remove the entire signature span before searching for internal call sites (prevents the function's own parameter list from triggering a false negative).
3. If the function name followed by `(` does not appear in the remaining source, it is externally-called-only → flag it.

### Example
```solidity
// ❌ Flagged — transfer is never called internally
function transfer(address to, uint256 amount) public returns (bool) { ... }

// ✅ Suggestion
function transfer(address to, uint256 amount) external returns (bool) { ... }
```

---

## #337 — Detect Constructor Visibility Issues

### Problem
Solidity ≥ 0.7.0 removed visibility modifiers (`public` / `internal`) from constructors — their presence is a **compile error**. In older code `public` was redundant and `internal` was used to mark abstract contracts. Legacy function-style constructors (`function ContractName(...)`) with visibility modifiers are also flagged.

### Implementation
| File | Description |
|------|-------------|
| `rules/security/constructors/detect-constructor-visibility.ts` | TypeScript rule — detects all four violation kinds |
| `packages/rules/src/security/constructors/constructor_visibility.rs` | Rust rule — implements `Rule` trait + standalone checker |
| `packages/rules/src/security/constructors/mod.rs` | Module wiring |
| `packages/rules/src/security/mod.rs` | Exports added |
| `tests/rules/detect-constructor-visibility.spec.ts` | 8 tests |

### Violation Kinds
| Kind | Description | Severity |
|------|-------------|----------|
| `constructor-public` | `constructor(...) public` | Medium |
| `constructor-internal` | `constructor(...) internal` | High |
| `legacy-constructor-public` | `function Name(...) public` | Medium |
| `legacy-constructor-internal` | `function Name(...) internal` | High |

### Example
```solidity
// ❌ Flagged — public is illegal in Solidity >=0.7.0
constructor(uint256 supply) public { ... }

// ✅ Fix
constructor(uint256 supply) { ... }

// ❌ Flagged — internal is illegal in >=0.7.0
constructor() internal {}

// ✅ Fix
abstract contract Base { constructor() {} }
```

---

## Testing

All **14 tests pass**:
- 6 tests for `detectUnnecessaryPublicFunctions`
- 8 tests for `detectConstructorVisibility`

```
PASS  tests/rules/detect-unnecessary-public-functions.spec.ts
PASS  tests/rules/detect-constructor-visibility.spec.ts

Tests: 14 passed, 14 total
```

---

Closes #338
Closes #337