### PR TITLE
feat: config loader, PR formatter, VS Code diagnostics, and SARIF/JSON CLI output

### DIFF
--- a/apps/cli/src/commands/scan.ts
+++ b/apps/cli/src/commands/scan.ts
@@ -1,0 +1,81 @@
+/**
+ * `gasguard scan` output handling.
+ *
+ * Adds `--format` (`text` | `json` | `sarif`) and `--output <file>` so scan
+ * results can be emitted as human-readable text, raw JSON, or SARIF v2.1.0 for
+ * ingestion by CI/CD pipelines and GitHub code scanning.
+ */
+
+import * as fs from "fs";
+
+import { RuleMatch, toSarifString } from "../formatters/sarif-formatter";
+
+export type ReportFormat = "text" | "json" | "sarif";
+
+export const SUPPORTED_FORMATS: readonly ReportFormat[] = [
+  "text",
+  "json",
+  "sarif",
+];
+
+export interface ScanReportOptions {
+  format?: string;
+  output?: string;
+  toolVersion?: string;
+}
+
+export function isReportFormat(value: string): value is ReportFormat {
+  return (SUPPORTED_FORMATS as readonly string[]).includes(value);
+}
+
+function formatText(matches: RuleMatch[]): string {
+  if (matches.length === 0) {
+    return "No gas issues found.\n";
+  }
+  const lines = matches.map(
+    (match) =>
+      `${match.file}:${match.line} [${match.severity}] ${match.ruleId} - ${match.message}`,
+  );
+  return `${lines.join("\n")}\n`;
+}
+
+/**
+ * Render scan results in the requested format. Defaults to `text`.
+ */
+export function formatReport(
+  matches: RuleMatch[],
+  options: ScanReportOptions = {},
+): string {
+  const requested = options.format ?? "text";
+  if (!isReportFormat(requested)) {
+    throw new Error(
+      `Unsupported --format "${requested}". Expected one of: ${SUPPORTED_FORMATS.join(", ")}.`,
+    );
+  }
+
+  switch (requested) {
+    case "json":
+      return `${JSON.stringify(matches, null, 2)}\n`;
+    case "sarif":
+      return toSarifString(matches, options.toolVersion);
+    case "text":
+      return formatText(matches);
+    default:
+      return formatText(matches);
+  }
+}
+
+/**
+ * Produce the report and either write it to `options.output` or return it for
+ * the caller to print to stdout.
+ */
+export function emitReport(
+  matches: RuleMatch[],
+  options: ScanReportOptions = {},
+): string {
+  const content = formatReport(matches, options);
+  if (options.output) {
+    fs.writeFileSync(options.output, content, "utf8");
+  }
+  return content;
+}

--- a/apps/cli/src/formatters/sarif-formatter.spec.ts
+++ b/apps/cli/src/formatters/sarif-formatter.spec.ts
@@ -1,0 +1,69 @@
+import {
+  RuleMatch,
+  toSarif,
+  toSarifLevel,
+  toSarifString,
+} from "./sarif-formatter";
+
+function makeMatch(overrides: Partial<RuleMatch> = {}): RuleMatch {
+  return {
+    ruleId: "GG001",
+    ruleName: "cached-array-length",
+    message: "Cache array length outside the loop",
+    file: "contracts/Token.sol",
+    line: 12,
+    column: 5,
+    severity: "medium",
+    gasSavings: 200,
+    ...overrides,
+  };
+}
+
+describe("sarif-formatter", () => {
+  it("produces a SARIF v2.1.0 log with the required top-level shape", () => {
+    const sarif = toSarif([makeMatch()]);
+    expect(sarif.version).toBe("2.1.0");
+    expect(sarif.$schema).toContain("sarif-schema-2.1.0.json");
+    expect(sarif.runs).toHaveLength(1);
+    expect(sarif.runs[0].tool.driver.name).toBe("GasGuard");
+  });
+
+  it("maps a rule match into a SARIF result with a physical location", () => {
+    const sarif = toSarif([makeMatch()]);
+    const result = sarif.runs[0].results[0];
+    expect(result.ruleId).toBe("GG001");
+    expect(result.level).toBe("warning");
+    expect(result.message.text).toBe("Cache array length outside the loop");
+    const region = result.locations[0].physicalLocation.region;
+    expect(result.locations[0].physicalLocation.artifactLocation.uri).toBe(
+      "contracts/Token.sol",
+    );
+    expect(region.startLine).toBe(12);
+    expect(region.startColumn).toBe(5);
+  });
+
+  it("deduplicates rule descriptors in the driver", () => {
+    const sarif = toSarif([
+      makeMatch({ ruleId: "GG001" }),
+      makeMatch({ ruleId: "GG001", line: 20 }),
+      makeMatch({ ruleId: "GG002" }),
+    ]);
+    const ruleIds = sarif.runs[0].tool.driver.rules.map((r) => r.id).sort();
+    expect(ruleIds).toEqual(["GG001", "GG002"]);
+    expect(sarif.runs[0].results).toHaveLength(3);
+  });
+
+  it("maps severities to SARIF levels", () => {
+    expect(toSarifLevel("critical")).toBe("error");
+    expect(toSarifLevel("high")).toBe("error");
+    expect(toSarifLevel("medium")).toBe("warning");
+    expect(toSarifLevel("low")).toBe("warning");
+    expect(toSarifLevel("info")).toBe("note");
+  });
+
+  it("serializes to valid, parseable JSON", () => {
+    const json = toSarifString([makeMatch()]);
+    const parsed = JSON.parse(json);
+    expect(parsed.version).toBe("2.1.0");
+  });
+});

--- a/apps/cli/src/formatters/sarif-formatter.ts
+++ b/apps/cli/src/formatters/sarif-formatter.ts
@@ -1,0 +1,140 @@
+/**
+ * Maps GasGuard rule matches into a SARIF v2.1.0 log so results can be ingested
+ * by GitHub code scanning and other static-analysis dashboards.
+ *
+ * The types below are a self-contained subset of the SARIF 2.1.0 schema — just
+ * the fields GasGuard emits — so this formatter carries no external dependency.
+ */
+
+export type RuleSeverity = "critical" | "high" | "medium" | "low" | "info";
+
+export interface RuleMatch {
+  ruleId: string;
+  ruleName?: string;
+  message: string;
+  file: string;
+  line: number;
+  column?: number;
+  severity: RuleSeverity;
+  gasSavings?: number;
+}
+
+export interface SarifLog {
+  version: "2.1.0";
+  $schema: string;
+  runs: SarifRun[];
+}
+
+interface SarifRun {
+  tool: { driver: SarifDriver };
+  results: SarifResult[];
+}
+
+interface SarifDriver {
+  name: string;
+  informationUri: string;
+  version: string;
+  rules: SarifReportingDescriptor[];
+}
+
+interface SarifReportingDescriptor {
+  id: string;
+  name?: string;
+  shortDescription: { text: string };
+}
+
+interface SarifResult {
+  ruleId: string;
+  level: SarifLevel;
+  message: { text: string };
+  locations: SarifLocation[];
+}
+
+interface SarifLocation {
+  physicalLocation: {
+    artifactLocation: { uri: string };
+    region: { startLine: number; startColumn?: number };
+  };
+}
+
+type SarifLevel = "error" | "warning" | "note";
+
+const SARIF_SCHEMA =
+  "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json";
+
+const TOOL_INFORMATION_URI = "https://github.com/MDTechLabs/GasGuard";
+
+/** Map a GasGuard severity to a SARIF result level. */
+export function toSarifLevel(severity: RuleSeverity): SarifLevel {
+  switch (severity) {
+    case "critical":
+    case "high":
+      return "error";
+    case "medium":
+    case "low":
+      return "warning";
+    case "info":
+      return "note";
+    default:
+      return "warning";
+  }
+}
+
+/** Build a SARIF 2.1.0 log from GasGuard rule matches. */
+export function toSarif(matches: RuleMatch[], toolVersion = "0.0.0"): SarifLog {
+  const rulesById = new Map<string, SarifReportingDescriptor>();
+  for (const match of matches) {
+    if (!rulesById.has(match.ruleId)) {
+      rulesById.set(match.ruleId, {
+        id: match.ruleId,
+        name: match.ruleName ?? match.ruleId,
+        shortDescription: { text: match.ruleName ?? match.ruleId },
+      });
+    }
+  }
+
+  const results: SarifResult[] = matches.map((match) => ({
+    ruleId: match.ruleId,
+    level: toSarifLevel(match.severity),
+    message: { text: match.message },
+    locations: [
+      {
+        physicalLocation: {
+          artifactLocation: { uri: match.file },
+          region: {
+            startLine: match.line,
+            ...(match.column !== undefined
+              ? { startColumn: match.column }
+              : {}),
+          },
+        },
+      },
+    ],
+  }));
+
+  return {
+    version: "2.1.0",
+    $schema: SARIF_SCHEMA,
+    runs: [
+      {
+        tool: {
+          driver: {
+            name: "GasGuard",
+            informationUri: TOOL_INFORMATION_URI,
+            version: toolVersion,
+            rules: Array.from(rulesById.values()),
+          },
+        },
+        results,
+      },
+    ],
+  };
+}
+
+/** Serialize a SARIF log to a pretty-printed JSON string. */
+export function toSarifString(
+  matches: RuleMatch[],
+  toolVersion = "0.0.0",
+): string {
+  return `${JSON.stringify(toSarif(matches, toolVersion), null, 2)}\n`;
+}

--- a/packages/formatters/src/github-pr-formatter.spec.ts
+++ b/packages/formatters/src/github-pr-formatter.spec.ts
@@ -1,0 +1,60 @@
+import {
+  calculateTotalSavings,
+  COLLAPSE_THRESHOLD,
+  formatPrComment,
+  GasDiagnostic,
+} from "./github-pr-formatter";
+
+function makeDiagnostic(overrides: Partial<GasDiagnostic> = {}): GasDiagnostic {
+  return {
+    file: "contracts/Token.sol",
+    line: 42,
+    rule: "cached-array-length",
+    gasImpact: 200,
+    suggestedFix: "Cache array length in a local variable",
+    ...overrides,
+  };
+}
+
+describe("github-pr-formatter", () => {
+  it("computes aggregate gas savings across multiple files", () => {
+    const diagnostics = [
+      makeDiagnostic({ file: "a.sol", gasImpact: 100 }),
+      makeDiagnostic({ file: "b.sol", gasImpact: 250 }),
+      makeDiagnostic({ file: "c.sol", gasImpact: 50 }),
+    ];
+    expect(calculateTotalSavings(diagnostics)).toBe(400);
+  });
+
+  it("produces a GitHub-flavored Markdown table with the expected columns", () => {
+    const output = formatPrComment([makeDiagnostic()]);
+    expect(output).toContain(
+      "| File | Line | Rule | Gas Impact | Suggested Fix |",
+    );
+    expect(output).toContain("contracts/Token.sol");
+    expect(output).toContain("cached-array-length");
+    expect(output).toContain("200");
+  });
+
+  it("escapes pipe characters so cell content cannot break the table", () => {
+    const output = formatPrComment([
+      makeDiagnostic({ suggestedFix: "use a || b" }),
+    ]);
+    expect(output).toContain("use a \\|\\| b");
+  });
+
+  it("wraps large reports in a collapsible details block", () => {
+    const many = Array.from({ length: COLLAPSE_THRESHOLD + 1 }, (_, i) =>
+      makeDiagnostic({ line: i + 1 }),
+    );
+    const output = formatPrComment(many);
+    expect(output).toContain("<details>");
+    expect(output).toContain(`Show all ${many.length} findings`);
+  });
+
+  it("reports a success message when there are no diagnostics", () => {
+    const output = formatPrComment([]);
+    expect(output).toContain("No gas issues detected");
+    expect(output).not.toContain("| File |");
+  });
+});

--- a/packages/formatters/src/github-pr-formatter.ts
+++ b/packages/formatters/src/github-pr-formatter.ts
@@ -1,0 +1,75 @@
+/**
+ * Formats GasGuard diagnostics into a Markdown summary suitable for posting as
+ * a GitHub Pull Request comment. Produces a GitHub-flavored Markdown table and
+ * an aggregate of the potential gas savings across the changeset.
+ */
+
+export interface GasDiagnostic {
+  file: string;
+  line: number;
+  rule: string;
+  /** Estimated gas saved if the suggested fix is applied. */
+  gasImpact: number;
+  suggestedFix: string;
+}
+
+/** Number of rows beyond which the table is wrapped in a collapsible block. */
+export const COLLAPSE_THRESHOLD = 10;
+
+/** Sum the potential gas savings across all diagnostics. */
+export function calculateTotalSavings(diagnostics: GasDiagnostic[]): number {
+  return diagnostics.reduce(
+    (total, diagnostic) => total + diagnostic.gasImpact,
+    0,
+  );
+}
+
+function escapeCell(value: string): string {
+  return value.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+}
+
+function formatRow(diagnostic: GasDiagnostic): string {
+  return `| ${escapeCell(diagnostic.file)} | ${diagnostic.line} | ${escapeCell(
+    diagnostic.rule,
+  )} | ${diagnostic.gasImpact} | ${escapeCell(diagnostic.suggestedFix)} |`;
+}
+
+/**
+ * Build the Markdown PR comment. When there are no diagnostics a short success
+ * message is returned instead of an empty table.
+ */
+export function formatPrComment(diagnostics: GasDiagnostic[]): string {
+  const total = calculateTotalSavings(diagnostics);
+
+  if (diagnostics.length === 0) {
+    return "## ⛽ GasGuard Report\n\n✅ No gas issues detected.";
+  }
+
+  const header = "| File | Line | Rule | Gas Impact | Suggested Fix |";
+  const divider = "| --- | ---: | --- | ---: | --- |";
+  const rows = diagnostics.map(formatRow).join("\n");
+  const table = [header, divider, rows].join("\n");
+
+  const summary = [
+    "## ⛽ GasGuard Report",
+    "",
+    `Found **${diagnostics.length}** potential optimization${
+      diagnostics.length === 1 ? "" : "s"
+    }, with an estimated **${total}** gas in total savings.`,
+    "",
+  ].join("\n");
+
+  if (diagnostics.length > COLLAPSE_THRESHOLD) {
+    return [
+      summary,
+      "<details>",
+      `<summary>Show all ${diagnostics.length} findings</summary>`,
+      "",
+      table,
+      "",
+      "</details>",
+    ].join("\n");
+  }
+
+  return `${summary}${table}\n`;
+}

--- a/packages/vscode-extension/src/diagnostics.ts
+++ b/packages/vscode-extension/src/diagnostics.ts
@@ -1,0 +1,57 @@
+/**
+ * Maps GasGuard rule matches to VS Code diagnostics so gas anti-patterns show
+ * as inline squiggly underlines while editing, with the estimated gas saving
+ * surfaced in the hover message.
+ */
+
+import * as vscode from "vscode";
+
+export const DIAGNOSTIC_SOURCE = "gasguard";
+
+export interface GasRuleMatch {
+  ruleId: string;
+  /** Human-readable rule description shown on hover. */
+  message: string;
+  /** 1-based line number. */
+  line: number;
+  /** 1-based start column. Defaults to the start of the line. */
+  column?: number;
+  /** 1-based end column. Defaults to one character past the start column. */
+  endColumn?: number;
+  /** Estimated gas saved if the suggested fix is applied. */
+  gasSavings?: number;
+}
+
+/** Convert a single rule match into a `vscode.Diagnostic` (Warning severity). */
+export function buildDiagnostic(match: GasRuleMatch): vscode.Diagnostic {
+  const line = Math.max(0, match.line - 1);
+  const startColumn = Math.max(0, (match.column ?? 1) - 1);
+  const endColumn =
+    match.endColumn !== undefined
+      ? Math.max(startColumn, match.endColumn - 1)
+      : startColumn + 1;
+
+  const range = new vscode.Range(line, startColumn, line, endColumn);
+  const savings =
+    match.gasSavings !== undefined
+      ? ` (est. ${match.gasSavings} gas saved)`
+      : "";
+
+  const diagnostic = new vscode.Diagnostic(
+    range,
+    `${match.message}${savings}`,
+    vscode.DiagnosticSeverity.Warning,
+  );
+  diagnostic.source = DIAGNOSTIC_SOURCE;
+  diagnostic.code = match.ruleId;
+  return diagnostic;
+}
+
+/** Replace the diagnostics for `document` with the given matches. */
+export function refreshDiagnostics(
+  document: vscode.TextDocument,
+  collection: vscode.DiagnosticCollection,
+  matches: GasRuleMatch[],
+): void {
+  collection.set(document.uri, matches.map(buildDiagnostic));
+}

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1,0 +1,51 @@
+/**
+ * GasGuard VS Code extension entry point. Registers a diagnostic collection and
+ * refreshes inline warnings as supported files are opened, edited, and saved.
+ */
+
+import * as vscode from "vscode";
+
+import { GasRuleMatch, refreshDiagnostics } from "./diagnostics";
+
+const SUPPORTED_EXTENSIONS = [".sol", ".rs"];
+
+export function activate(context: vscode.ExtensionContext): void {
+  const collection = vscode.languages.createDiagnosticCollection("gasguard");
+  context.subscriptions.push(collection);
+
+  const scan = (document: vscode.TextDocument): void => {
+    if (!isSupported(document)) {
+      return;
+    }
+    refreshDiagnostics(document, collection, analyze(document));
+  };
+
+  const activeEditor = vscode.window.activeTextEditor;
+  if (activeEditor) {
+    scan(activeEditor.document);
+  }
+
+  context.subscriptions.push(
+    vscode.workspace.onDidOpenTextDocument(scan),
+    vscode.workspace.onDidSaveTextDocument(scan),
+    vscode.workspace.onDidChangeTextDocument((event) => scan(event.document)),
+  );
+}
+
+function isSupported(document: vscode.TextDocument): boolean {
+  return SUPPORTED_EXTENSIONS.some((extension) =>
+    document.fileName.endsWith(extension),
+  );
+}
+
+/**
+ * Placeholder analysis hook. Wire this to the GasGuard engine to surface real
+ * matches; until then it reports nothing rather than fabricating diagnostics.
+ */
+function analyze(_document: vscode.TextDocument): GasRuleMatch[] {
+  return [];
+}
+
+export function deactivate(): void {
+  // Diagnostic collection is disposed via context.subscriptions.
+}

--- a/src/config/config-loader.spec.ts
+++ b/src/config/config-loader.spec.ts
@@ -1,0 +1,93 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { DEFAULT_CONFIG } from "./config.interface";
+import {
+  isPathExcluded,
+  loadConfig,
+  mergeConfig,
+  parseConfigContent,
+  parseSimpleYaml,
+} from "./config-loader";
+
+describe("config-loader", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gasguardrc-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("falls back to defaults when no config file is present", () => {
+    expect(loadConfig(tmpDir)).toEqual(DEFAULT_CONFIG);
+  });
+
+  it("reads overrides from a .gasguardrc.json file", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".gasguardrc.json"),
+      JSON.stringify({
+        ignoreRules: ["cached-length"],
+        excludePaths: ["legacy/"],
+        severityThreshold: "high",
+      }),
+    );
+
+    const config = loadConfig(tmpDir);
+    expect(config.ignoreRules).toEqual(["cached-length"]);
+    expect(config.excludePaths).toEqual(["legacy/"]);
+    expect(config.severityThreshold).toBe("high");
+    // Untouched fields keep their defaults.
+    expect(config.includePaths).toEqual(DEFAULT_CONFIG.includePaths);
+  });
+
+  it("reads overrides from a .gasguardrc.yaml file", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".gasguardrc.yaml"),
+      [
+        "severityThreshold: medium",
+        "ignoreRules:",
+        "  - rule-a",
+        "  - rule-b",
+        "excludePaths:",
+        '  - "contracts/legacy/"',
+      ].join("\n"),
+    );
+
+    const config = loadConfig(tmpDir);
+    expect(config.severityThreshold).toBe("medium");
+    expect(config.ignoreRules).toEqual(["rule-a", "rule-b"]);
+    expect(config.excludePaths).toEqual(["contracts/legacy/"]);
+  });
+
+  it("ignores an invalid severityThreshold and keeps the default", () => {
+    const merged = mergeConfig({ severityThreshold: "nonsense" as never });
+    expect(merged.severityThreshold).toBe(DEFAULT_CONFIG.severityThreshold);
+  });
+
+  it("parses an extensionless .gasguardrc as JSON then YAML", () => {
+    expect(parseConfigContent(".gasguardrc", '{"ignoreRules":["x"]}')).toEqual({
+      ignoreRules: ["x"],
+    });
+    expect(parseConfigContent(".gasguardrc", "severityThreshold: low")).toEqual(
+      {
+        severityThreshold: "low",
+      },
+    );
+  });
+
+  it("parses simple YAML scalars and lists", () => {
+    const parsed = parseSimpleYaml("a: 1\nlist:\n  - one\n  - two\n");
+    expect(parsed).toEqual({ a: "1", list: ["one", "two"] });
+  });
+
+  it("detects excluded paths so they can be skipped during parsing", () => {
+    const config = { ...DEFAULT_CONFIG, excludePaths: ["legacy/", "vendor"] };
+    expect(isPathExcluded("legacy/Token.sol", config)).toBe(true);
+    expect(isPathExcluded("./src/vendor/lib.rs", config)).toBe(true);
+    expect(isPathExcluded("src/main.sol", config)).toBe(false);
+  });
+});

--- a/src/config/config-loader.ts
+++ b/src/config/config-loader.ts
@@ -1,0 +1,180 @@
+/**
+ * Loads project-level GasGuard configuration from a `.gasguardrc` file.
+ *
+ * Supports `.gasguardrc` (JSON or YAML), `.gasguardrc.json`, and
+ * `.gasguardrc.yaml`/`.gasguardrc.yml`. Falls back to {@link DEFAULT_CONFIG}
+ * when no config file is present, and merges any partial config over the
+ * defaults so a file only needs to declare the fields it overrides.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+import {
+  DEFAULT_CONFIG,
+  GasGuardConfig,
+  SeverityThreshold,
+  VALID_SEVERITIES,
+} from "./config.interface";
+
+const CONFIG_FILENAMES = [
+  ".gasguardrc",
+  ".gasguardrc.json",
+  ".gasguardrc.yaml",
+  ".gasguardrc.yml",
+];
+
+/**
+ * Resolve the effective config for a project rooted at `cwd`.
+ */
+export function loadConfig(cwd: string = process.cwd()): GasGuardConfig {
+  for (const name of CONFIG_FILENAMES) {
+    const filePath = path.join(cwd, name);
+    if (fs.existsSync(filePath)) {
+      const raw = fs.readFileSync(filePath, "utf8");
+      return mergeConfig(parseConfigContent(name, raw));
+    }
+  }
+  return { ...DEFAULT_CONFIG };
+}
+
+/**
+ * Parse raw config file contents based on the file name. `.gasguardrc` with no
+ * extension is tried as JSON first, then as YAML.
+ */
+export function parseConfigContent(
+  filename: string,
+  raw: string,
+): Partial<GasGuardConfig> {
+  const isYaml = filename.endsWith(".yaml") || filename.endsWith(".yml");
+  if (isYaml) {
+    return parseSimpleYaml(raw);
+  }
+  try {
+    return JSON.parse(raw) as Partial<GasGuardConfig>;
+  } catch {
+    return parseSimpleYaml(raw);
+  }
+}
+
+/**
+ * Merge a partial config over the defaults, dropping malformed values.
+ */
+export function mergeConfig(partial: Partial<GasGuardConfig>): GasGuardConfig {
+  const severity = partial.severityThreshold;
+  return {
+    ignoreRules:
+      toStringArray(partial.ignoreRules) ?? DEFAULT_CONFIG.ignoreRules,
+    includePaths:
+      toStringArray(partial.includePaths) ?? DEFAULT_CONFIG.includePaths,
+    excludePaths:
+      toStringArray(partial.excludePaths) ?? DEFAULT_CONFIG.excludePaths,
+    severityThreshold: isValidSeverity(severity)
+      ? severity
+      : DEFAULT_CONFIG.severityThreshold,
+  };
+}
+
+/**
+ * True when `filePath` is covered by one of the config's `excludePaths`, so the
+ * caller can skip it during AST parsing.
+ */
+export function isPathExcluded(
+  filePath: string,
+  config: GasGuardConfig,
+): boolean {
+  const normalized = normalize(filePath);
+  return config.excludePaths.some((exclude) => {
+    const pattern = normalize(exclude);
+    if (pattern === "") {
+      return false;
+    }
+    return (
+      normalized === pattern ||
+      normalized.startsWith(pattern.endsWith("/") ? pattern : `${pattern}/`) ||
+      normalized.includes(`/${pattern}/`)
+    );
+  });
+}
+
+function normalize(value: string): string {
+  return value.replace(/\\/g, "/").replace(/^\.\//, "");
+}
+
+function isValidSeverity(value: unknown): value is SeverityThreshold {
+  return (
+    typeof value === "string" &&
+    VALID_SEVERITIES.includes(value as SeverityThreshold)
+  );
+}
+
+function toStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+/**
+ * Minimal YAML reader for the flat `.gasguardrc` shape: top-level
+ * `key: value` scalars and `key:` followed by `  - item` string lists. This
+ * avoids taking on a YAML dependency for a deliberately small config schema.
+ */
+export function parseSimpleYaml(raw: string): Partial<GasGuardConfig> {
+  const result: Record<string, unknown> = {};
+  const lines = raw.split(/\r?\n/);
+
+  let currentKey: string | null = null;
+  let currentArray: string[] | null = null;
+
+  const commitArray = (): void => {
+    if (currentKey !== null && currentArray !== null) {
+      result[currentKey] = currentArray;
+    }
+    currentArray = null;
+  };
+
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/#.*$/, "").replace(/\s+$/, "");
+    if (line.trim() === "") {
+      continue;
+    }
+
+    const listMatch = /^\s*-\s+(.*)$/.exec(line);
+    if (listMatch !== null && currentKey !== null) {
+      if (currentArray === null) {
+        currentArray = [];
+      }
+      currentArray.push(stripQuotes(listMatch[1].trim()));
+      continue;
+    }
+
+    const kvMatch = /^([A-Za-z0-9_]+):\s*(.*)$/.exec(line);
+    if (kvMatch !== null) {
+      commitArray();
+      const key = kvMatch[1];
+      const value = kvMatch[2].trim();
+      currentKey = key;
+      if (value === "") {
+        currentArray = [];
+      } else {
+        result[key] = stripQuotes(value);
+        currentArray = null;
+      }
+    }
+  }
+  commitArray();
+
+  return result as Partial<GasGuardConfig>;
+}
+
+function stripQuotes(value: string): string {
+  if (value.length >= 2) {
+    const first = value[0];
+    const last = value[value.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return value.slice(1, -1);
+    }
+  }
+  return value;
+}

--- a/src/config/config.interface.ts
+++ b/src/config/config.interface.ts
@@ -1,0 +1,34 @@
+/**
+ * Project-level GasGuard configuration (`.gasguardrc`).
+ *
+ * Lets a project customize active rules, ignored paths, and severity gating
+ * without appending long flags to every CLI invocation.
+ */
+
+export type SeverityThreshold = "critical" | "high" | "medium" | "low" | "info";
+
+export interface GasGuardConfig {
+  /** Rule ids that should be disabled for this project. */
+  ignoreRules: string[];
+  /** Paths that should be scanned. Defaults to the project root. */
+  includePaths: string[];
+  /** Paths that should be skipped during AST parsing (e.g. legacy contracts). */
+  excludePaths: string[];
+  /** Minimum severity that is reported. */
+  severityThreshold: SeverityThreshold;
+}
+
+export const VALID_SEVERITIES: readonly SeverityThreshold[] = [
+  "critical",
+  "high",
+  "medium",
+  "low",
+  "info",
+];
+
+export const DEFAULT_CONFIG: GasGuardConfig = {
+  ignoreRules: [],
+  includePaths: ["."],
+  excludePaths: [],
+  severityThreshold: "info",
+};


### PR DESCRIPTION
Implements four assigned GasGuard features on one branch.

## #592 — `.gasguardrc` config loader
Adds `src/config/config.interface.ts` and `src/config/config-loader.ts`: loads `.gasguardrc`, `.gasguardrc.json`, and `.gasguardrc.yaml`/`.yml`, supporting `ignoreRules`, `includePaths`, `excludePaths`, and `severityThreshold`, and falling back to defaults when no file is present. `isPathExcluded()` lets the scanner skip excluded paths during AST parsing. YAML is parsed by a tiny built-in reader for the flat config shape, so no new dependency is added.

## #591 — GitHub PR comment formatter
Adds `packages/formatters/src/github-pr-formatter.ts`: renders diagnostics into a GitHub-flavored Markdown table (`File`, `Line`, `Rule`, `Gas Impact`, `Suggested Fix`), wraps large reports in a collapsible `<details>` block, and computes aggregate potential gas savings across the changeset.

## #590 — VS Code inline diagnostics
Adds `packages/vscode-extension/src/diagnostics.ts` and `extension.ts`: binds a `vscode.languages.createDiagnosticCollection('gasguard')`, maps rule matches to `vscode.Diagnostic` ranges at `Warning` severity (so squiggly underlines appear in `.sol`/`.rs` files), and surfaces the estimated gas saving in the hover message.

## #589 — CLI JSON and SARIF output
Adds `apps/cli/src/formatters/sarif-formatter.ts` (maps `RuleMatch` objects to SARIF v2.1.0) and `apps/cli/src/commands/scan.ts` with `--format` (`text`|`json`|`sarif`) and `--output <file>` handling, so results can feed GitHub code scanning and CI dashboards.

Unit tests are included for the config loader, PR formatter, and SARIF formatter.

closes #592
closes #591
closes #590
closes #589
