### PR TITLE
feat: implement immutable/constant state variable detection

### DIFF
--- a/packages/rules/solidity/src/immutable-check.ts
+++ b/packages/rules/solidity/src/immutable-check.ts
@@ -1,0 +1,166 @@
+export interface ImmutableConstantWarning {
+  line: number;
+  variableName: string;
+  variableType: string;
+  modifier: 'immutable' | 'constant';
+  message: string;
+  suggestedRefactor: string;
+}
+
+interface StateVariable {
+  name: string;
+  type: string;
+  line: number;
+  visibility: string;
+  hasConstant: boolean;
+  hasImmutable: boolean;
+  hasInlineInitializer: boolean;
+}
+
+interface FunctionBody {
+  name: string;
+  startLine: number;
+  endLine: number;
+  body: string;
+}
+
+function stripComments(code: string): string {
+  return code.replace(/\/\/[^\n]*/g, '').replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+function extractStateVariables(sourceCode: string): StateVariable[] {
+  const variables: StateVariable[] = [];
+  const lines = sourceCode.split('\n');
+  const stateVarPattern = /^\s*(mapping\s*\(|[A-Za-z_$][\w$]*(?:\[\])*(?:\s*<[^>]+>)?)\s+(constant\s+)?(immutable\s+)?(public|private|internal|external)?\s*([A-Za-z_$][\w$]*)\s*(?:=\s*[^;]+)?\s*;/;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trim();
+
+    if (/^(function|event|modifier|constructor|struct|enum|interface|library)\s/.test(trimmed)) {
+      break;
+    }
+
+    if (!trimmed || trimmed.startsWith('//') || trimmed.startsWith('/*')) {
+      continue;
+    }
+
+    const match = line.match(stateVarPattern);
+    if (match) {
+      const hasInlineInitializer = /=\s*[^;]+;/.test(line);
+      variables.push({
+        name: match[5],
+        type: match[1].trim(),
+        line: i + 1,
+        visibility: match[4] || 'internal',
+        hasConstant: match[2] !== undefined,
+        hasImmutable: match[3] !== undefined,
+        hasInlineInitializer,
+      });
+    }
+  }
+
+  return variables;
+}
+
+function extractFunctionBodies(sourceCode: string): FunctionBody[] {
+  const functions: FunctionBody[] = [];
+  const lines = sourceCode.split('\n');
+  const funcPattern = /^\s*(function\s+(\w+)|constructor)\s*\([^)]*\)\s*[^{]*\{/;
+
+  for (let i = 0; i < lines.length; i++) {
+    const match = lines[i].match(funcPattern);
+    if (match) {
+      let braceDepth = 0;
+      const bodyLines: string[] = [];
+      let bodyStarted = false;
+
+      for (let j = i; j < lines.length; j++) {
+        const line = lines[j];
+        const opens = (line.match(/\{/g) || []).length;
+        const closes = (line.match(/\}/g) || []).length;
+
+        if (opens > 0) bodyStarted = true;
+        if (bodyStarted) bodyLines.push(line);
+        braceDepth += opens - closes;
+
+        if (bodyStarted && braceDepth === 0) {
+          functions.push({
+            name: match[2] || 'constructor',
+            startLine: i + 1,
+            endLine: j + 1,
+            body: bodyLines.slice(1, -1).join('\n'),
+          });
+          break;
+        }
+      }
+    }
+  }
+
+  return functions;
+}
+
+function isVariableWrittenInBody(body: string, varName: string): boolean {
+  const assignmentPattern = new RegExp(`\\b${varName}\\b\\s*(?:\\[.*?\\])?\\s*=[^=]`);
+  return assignmentPattern.test(body);
+}
+
+function isConstantCandidate(variable: StateVariable): boolean {
+  return !variable.hasConstant && !variable.hasImmutable && variable.hasInlineInitializer;
+}
+
+function isImmutableCandidate(variable: StateVariable): boolean {
+  return !variable.hasConstant && !variable.hasImmutable && !variable.hasInlineInitializer;
+}
+
+export class SolidityImmutableCheckRule {
+  public static readonly RULE_ID = 'solidity-immutable-check';
+
+  public analyze(sourceCode: string): ImmutableConstantWarning[] {
+    const warnings: ImmutableConstantWarning[] = [];
+    const strippedCode = stripComments(sourceCode);
+    const stateVariables = extractStateVariables(strippedCode);
+    const functions = extractFunctionBodies(strippedCode);
+
+    for (const variable of stateVariables) {
+      if (variable.hasConstant || variable.hasImmutable) {
+        continue;
+      }
+
+      const constructorFunc = functions.find(f => f.name === 'constructor');
+      const nonConstructorFuncs = functions.filter(f => f.name !== 'constructor');
+
+      if (isConstantCandidate(variable)) {
+        const writtenInConstructor = constructorFunc && isVariableWrittenInBody(constructorFunc.body, variable.name);
+        const writtenOutside = nonConstructorFuncs.some(f => isVariableWrittenInBody(f.body, variable.name));
+
+        if (!writtenInConstructor && !writtenOutside) {
+          warnings.push({
+            line: variable.line,
+            variableName: variable.name,
+            variableType: variable.type,
+            modifier: 'constant',
+            message: `State variable '${variable.name}' is only assigned at declaration. Consider marking as 'constant' to save gas.`,
+            suggestedRefactor: `${variable.type} constant ${variable.visibility} ${variable.name} = <value>;`,
+          });
+        }
+      } else if (isImmutableCandidate(variable)) {
+        const writtenInConstructor = constructorFunc && isVariableWrittenInBody(constructorFunc.body, variable.name);
+        const writtenOutside = nonConstructorFuncs.some(f => isVariableWrittenInBody(f.body, variable.name));
+
+        if (writtenInConstructor && !writtenOutside) {
+          warnings.push({
+            line: variable.line,
+            variableName: variable.name,
+            variableType: variable.type,
+            modifier: 'immutable',
+            message: `State variable '${variable.name}' is only assigned in the constructor. Consider marking as 'immutable' to save gas.`,
+            suggestedRefactor: `${variable.type} immutable ${variable.visibility} ${variable.name};`,
+          });
+        }
+      }
+    }
+
+    return warnings;
+  }
+}

--- a/packages/rules/solidity/tests/immutable-check.spec.ts
+++ b/packages/rules/solidity/tests/immutable-check.spec.ts
@@ -1,0 +1,130 @@
+import { SolidityImmutableCheckRule } from '../src/immutable-check';
+
+describe('SolidityImmutableCheckRule', () => {
+  let rule: SolidityImmutableCheckRule;
+
+  beforeEach(() => {
+    rule = new SolidityImmutableCheckRule();
+  });
+
+  it('should detect a constant candidate variable assigned only at declaration', () => {
+    const code = `
+      contract TestContract {
+        uint256 public MAX_SUPPLY = 10000;
+      }
+    `;
+    const warnings = rule.analyze(code);
+    expect(warnings.length).toBe(1);
+    expect(warnings[0].variableName).toBe('MAX_SUPPLY');
+    expect(warnings[0].modifier).toBe('constant');
+  });
+
+  it('should detect an immutable candidate variable assigned only in the constructor', () => {
+    const code = `
+      contract TestContract {
+        address public owner;
+
+        constructor(address _owner) {
+          owner = _owner;
+        }
+      }
+    `;
+    const warnings = rule.analyze(code);
+    expect(warnings.length).toBe(1);
+    expect(warnings[0].variableName).toBe('owner');
+    expect(warnings[0].modifier).toBe('immutable');
+  });
+
+  it('should not flag variables already marked as constant', () => {
+    const code = `
+      contract TestContract {
+        uint256 public constant MAX_SUPPLY = 10000;
+      }
+    `;
+    const warnings = rule.analyze(code);
+    expect(warnings.length).toBe(0);
+  });
+
+  it('should not flag variables already marked as immutable', () => {
+    const code = `
+      contract TestContract {
+        address public immutable owner;
+
+        constructor(address _owner) {
+          owner = _owner;
+        }
+      }
+    `;
+    const warnings = rule.analyze(code);
+    expect(warnings.length).toBe(0);
+  });
+
+  it('should not flag variables modified in functions outside the constructor', () => {
+    const code = `
+      contract TestContract {
+        address public owner;
+
+        constructor(address _owner) {
+          owner = _owner;
+        }
+
+        function transferOwnership(address newOwner) public {
+          owner = newOwner;
+        }
+      }
+    `;
+    const warnings = rule.analyze(code);
+    expect(warnings.length).toBe(0);
+  });
+
+  it('should not flag variables that are never assigned', () => {
+    const code = `
+      contract TestContract {
+        uint256 public counter;
+      }
+    `;
+    const warnings = rule.analyze(code);
+    expect(warnings.length).toBe(0);
+  });
+
+  it('should flag multiple candidates in the same contract', () => {
+    const code = `
+      contract TestContract {
+        uint256 public MAX_SUPPLY = 10000;
+        address public owner;
+        string public name = "Test";
+
+        constructor(address _owner) {
+          owner = _owner;
+        }
+      }
+    `;
+    const warnings = rule.analyze(code);
+    expect(warnings.length).toBe(3);
+    const names = warnings.map(w => w.variableName);
+    expect(names).toContain('MAX_SUPPLY');
+    expect(names).toContain('owner');
+    expect(names).toContain('name');
+  });
+
+  it('should handle contracts with no constructor', () => {
+    const code = `
+      contract TestContract {
+        uint256 public MAX_SUPPLY = 10000;
+      }
+    `;
+    const warnings = rule.analyze(code);
+    expect(warnings.length).toBe(1);
+    expect(warnings[0].modifier).toBe('constant');
+  });
+
+  it('should not flag mapping state variables', () => {
+    const code = `
+      contract TestContract {
+        mapping(address => uint256) public balances;
+      }
+    `;
+    const warnings = rule.analyze(code);
+    expect(warnings.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the  that detects state variables in Solidity contracts that could be marked as  or  to save gas.

## Changes

- **New rule**:  - Class-based rule following the existing pattern
- **New tests**:  - 8 test cases covering all scenarios

## Features

- Detects **constant candidates**: variables only assigned at declaration (never written elsewhere)
- Detects **immutable candidates**: variables only assigned in the constructor (never modified after)
- Ignores variables already marked as  or 
- Ignores variables modified in functions outside the constructor
- Provides suggested refactoring for each finding

## Issues Closed

- Closes #593
- Closes #602
- Closes #603