### PR TITLE
feat: Yul array/calldata gas utils, memory profiler, and compact proxy pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 node_modules
 /target
 
+# Foundry / Hardhat build output
+/out
+/cache
+/artifacts
+/typechain-types
+
 # Production
 dist
 build

--- a/contracts/calldata/CalldataUnpacker.sol
+++ b/contracts/calldata/CalldataUnpacker.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title CalldataUnpacker
+/// @notice Gas-optimized decoder for tightly bit-packed multicall payloads.
+/// Each packed entry is exactly 32 bytes — a 20-byte recipient address
+/// followed by a 12-byte `uint96` amount, concatenated back-to-back with
+/// none of the standard ABI's 32-byte-per-field padding. Entries are decoded
+/// straight off `calldata` with `calldataload` and bit shifts, so unpacking
+/// never allocates an intermediate `memory` array the way `abi.decode` does.
+contract CalldataUnpacker {
+    /// @dev Size in bytes of a single packed entry (20-byte address +
+    /// 12-byte uint96).
+    uint256 private constant ENTRY_SIZE = 32;
+
+    /// @dev Standard ABI-encoded comparison format used only by
+    /// {multicallAbiDecodeBaseline} to benchmark against.
+    struct Entry {
+        address recipient;
+        uint96 amount;
+    }
+
+    error InvalidPayloadLength();
+
+    event Unpacked(address indexed recipient, uint96 amount);
+
+    mapping(address => uint256) public totalReceived;
+
+    /// @notice Decodes and processes a batch of transfers from a tightly
+    /// packed payload (`entryCount * 32` bytes, no ABI padding), reading
+    /// every field directly from `calldata`.
+    /// @param payload The packed entries, concatenated back-to-back.
+    /// @return processed Number of entries decoded and applied.
+    function unpackBatch(bytes calldata payload) external returns (uint256 processed) {
+        uint256 length = payload.length;
+        if (length == 0 || length % ENTRY_SIZE != 0) revert InvalidPayloadLength();
+
+        uint256 entryCount = length / ENTRY_SIZE;
+        for (uint256 i = 0; i < entryCount; ) {
+            (address recipient, uint96 amount) = _unpackEntry(payload, i);
+            totalReceived[recipient] += amount;
+            emit Unpacked(recipient, amount);
+            unchecked {
+                ++i;
+            }
+        }
+
+        processed = entryCount;
+    }
+
+    /// @notice Exposes {_unpackEntry} for direct unit testing / gas
+    /// measurement of a single decode.
+    function decodeEntryAt(bytes calldata payload, uint256 index) external pure returns (address recipient, uint96 amount) {
+        return _unpackEntry(payload, index);
+    }
+
+    /// @notice Standard `abi.decode` baseline: the same batch of transfers,
+    /// but ABI-encoded as `Entry[]` (32-byte-padded per field, plus offset
+    /// and length words), decoded into a `memory` array the conventional
+    /// way. Used to measure the gas savings {unpackBatch} achieves.
+    function multicallAbiDecodeBaseline(bytes calldata payload) external returns (uint256 processed) {
+        Entry[] memory entries = abi.decode(payload, (Entry[]));
+        for (uint256 i = 0; i < entries.length; ) {
+            totalReceived[entries[i].recipient] += entries[i].amount;
+            emit Unpacked(entries[i].recipient, entries[i].amount);
+            unchecked {
+                ++i;
+            }
+        }
+        processed = entries.length;
+    }
+
+    /// @dev Reads the 32-byte word at `payload[index * 32 : index * 32 + 32]`
+    /// directly from calldata and splits it into a 20-byte address (top
+    /// bits) and a 12-byte uint96 amount (bottom bits) via shifts — no
+    /// bounds-padded ABI field, no memory copy.
+    function _unpackEntry(bytes calldata payload, uint256 index) private pure returns (address recipient, uint96 amount) {
+        assembly {
+            let word := calldataload(add(payload.offset, mul(index, 32)))
+            recipient := shr(96, word)
+            amount := and(word, sub(shl(96, 1), 1))
+        }
+    }
+}

--- a/contracts/libraries/DelegateLogicLib.sol
+++ b/contracts/libraries/DelegateLogicLib.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title DelegateLogicLib
+/// @notice Heavy, reusable computation extracted out of `CompactImplementation`.
+/// @dev Every function below is declared `public`, so the compiler emits it
+/// as a *separately deployable* library contract and replaces each call
+/// site in `CompactImplementation` with a small `DELEGATECALL`/`CALL` stub —
+/// unlike `internal` library functions, which the compiler inlines into
+/// every caller's own bytecode and which therefore provide no deployment
+/// size benefit. Keeping the logic here means `CompactImplementation` stays
+/// well under the EIP-170 24,576-byte limit no matter how much this library
+/// grows.
+library DelegateLogicLib {
+    uint256 internal constant BPS_DENOMINATOR = 10_000;
+
+    struct Tier {
+        uint256 minVolume;
+        uint256 discountBps;
+    }
+
+    /// @notice Resolves which fee tier `volume` falls into out of `tiers`
+    /// (sorted ascending by `minVolume`) and returns its discount, in basis
+    /// points.
+    function resolveTierDiscount(Tier[] memory tiers, uint256 volume) public pure returns (uint256 discountBps) {
+        for (uint256 i = tiers.length; i > 0; ) {
+            unchecked {
+                --i;
+            }
+            if (volume >= tiers[i].minVolume) {
+                return tiers[i].discountBps;
+            }
+        }
+        return 0;
+    }
+
+    /// @notice Applies a basis-point discount to `amount`.
+    function applyDiscount(uint256 amount, uint256 discountBps) public pure returns (uint256) {
+        if (discountBps >= BPS_DENOMINATOR) return 0;
+        return amount - ((amount * discountBps) / BPS_DENOMINATOR);
+    }
+
+    /// @notice Resolves a caller's tier once and applies its discount across
+    /// an entire batch of raw fees, returning the subsidized total.
+    function computeBatchFee(Tier[] memory tiers, uint256 cumulativeVolume, uint256[] memory rawFees)
+        public
+        pure
+        returns (uint256 total)
+    {
+        uint256 discountBps = resolveTierDiscount(tiers, cumulativeVolume);
+        for (uint256 i = 0; i < rawFees.length; ) {
+            total += applyDiscount(rawFees[i], discountBps);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /// @notice Rolling-window rate-limit check. `windowUsage` decays
+    /// linearly to zero over `windowSize`; returns whether adding
+    /// `requested` more usage stays within `limit`, plus the resulting
+    /// usage value to persist.
+    function checkRateLimit(uint256 windowUsage, uint256 elapsed, uint256 windowSize, uint256 limit, uint256 requested)
+        public
+        pure
+        returns (bool allowed, uint256 newUsage)
+    {
+        uint256 decayed = elapsed >= windowSize ? 0 : windowUsage - ((windowUsage * elapsed) / windowSize);
+        newUsage = decayed + requested;
+        allowed = newUsage <= limit;
+    }
+
+    /// @notice Recovers the signer of an EIP-191 personal-sign digest over
+    /// `hash`, used to authorize privileged tier updates without needing
+    /// bespoke access-control code inline in the implementation contract.
+    function recoverAuthorizer(bytes32 hash, bytes memory signature) public pure returns (address) {
+        if (signature.length != 65) return address(0);
+
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        assembly {
+            r := mload(add(signature, 0x20))
+            s := mload(add(signature, 0x40))
+            v := byte(0, mload(add(signature, 0x60)))
+        }
+        if (v < 27) v += 27;
+
+        bytes32 ethSignedHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash));
+        return ecrecover(ethSignedHash, v, r, s);
+    }
+}

--- a/contracts/profiler/MemoryCheck.sol
+++ b/contracts/profiler/MemoryCheck.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title MemoryCheck
+/// @notice On-chain instrumentation for inspecting EVM free-memory-pointer
+/// growth and quadratic memory-expansion gas costs, complementing GasGuard's
+/// static `memory_profiler` analyzer (`gasguard-cli/src/analyzers`) with
+/// runtime ground-truth measurements.
+/// @dev The EVM's memory expansion cost formula is
+/// `C_mem(a) = 3a + floor(a^2 / 512)`, where `a` is the highest memory
+/// offset touched so far, expressed in 32-byte words.
+contract MemoryCheck {
+    /// @dev Memory slot the Solidity convention reserves for the free
+    /// memory pointer.
+    uint256 private constant FREE_MEMORY_POINTER_SLOT = 0x40;
+
+    /// @notice Allocations at or above this size are flagged as a critical
+    /// quadratic-expansion risk.
+    uint256 public constant CRITICAL_ALLOCATION_THRESHOLD = 1024;
+
+    /// @notice Emitted after {simulateAllocation} records a new allocation.
+    event MemoryUsageRecorded(bytes32 indexed label, uint256 freeMemoryPointer, uint256 expansionGasCost, bool critical);
+
+    /// @notice Reads the current free memory pointer directly from memory.
+    function freeMemoryPointer() public pure returns (uint256 ptr) {
+        assembly {
+            ptr := mload(FREE_MEMORY_POINTER_SLOT)
+        }
+    }
+
+    /// @notice Computes the EVM memory expansion cost for a region of
+    /// `sizeBytes`, using the canonical formula on the size rounded up to a
+    /// whole number of 32-byte words.
+    function memoryExpansionCost(uint256 sizeBytes) public pure returns (uint256 cost) {
+        uint256 words = (sizeBytes + 31) / 32;
+        cost = 3 * words + (words * words) / 512;
+    }
+
+    /// @notice True if a `sizeBytes` allocation exceeds the critical
+    /// quadratic-expansion threshold.
+    function isCriticalAllocation(uint256 sizeBytes) public pure returns (bool) {
+        return sizeBytes > CRITICAL_ALLOCATION_THRESHOLD;
+    }
+
+    /// @notice Allocates a scratch memory buffer of `sizeBytes`, measures how
+    /// far the free memory pointer actually moved, and emits the resulting
+    /// expansion cost and critical-risk flag for off-chain tooling to
+    /// correlate against the static analyzer's predictions.
+    /// @param label Caller-supplied identifier (e.g. the function under
+    /// review) so results are attributable in logs.
+    /// @param sizeBytes Size of the scratch buffer to allocate.
+    function simulateAllocation(bytes32 label, uint256 sizeBytes)
+        external
+        returns (uint256 delta, uint256 cost, bool critical)
+    {
+        uint256 before = freeMemoryPointer();
+        bytes memory scratch = new bytes(sizeBytes);
+        require(scratch.length == sizeBytes, "MemoryCheck: alloc mismatch");
+
+        delta = freeMemoryPointer() - before;
+        cost = memoryExpansionCost(delta);
+        critical = isCriticalAllocation(delta);
+
+        emit MemoryUsageRecorded(label, freeMemoryPointer(), cost, critical);
+    }
+}

--- a/contracts/proxy/CompactImplementation.sol
+++ b/contracts/proxy/CompactImplementation.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {DelegateLogicLib} from "../libraries/DelegateLogicLib.sol";
+
+/// @title CompactImplementation
+/// @notice Upgradeable tiered-fee logic contract for GasGuard's gas-subsidy
+/// module. Every non-trivial computation — tier resolution, discount math,
+/// batch fee aggregation, rolling rate limiting and signature recovery — is
+/// delegated to {DelegateLogicLib}'s external library functions rather than
+/// implemented inline, keeping this contract's own deployed bytecode small
+/// and comfortably clear of the EIP-170 24,576-byte limit.
+/// @dev Intended to sit behind a minimal proxy (e.g. EIP-1967); the pattern
+/// demonstrated here is what keeps *this* implementation contract compact
+/// as its feature set grows — new logic should be added to
+/// `DelegateLogicLib`, not inlined here.
+contract CompactImplementation {
+    error NotAuthorizer();
+    error RateLimited();
+
+    address public authorizer;
+    DelegateLogicLib.Tier[] public tiers;
+
+    mapping(address => uint256) public cumulativeVolume;
+    mapping(address => uint256) public rateWindowUsage;
+    mapping(address => uint256) public rateWindowStart;
+
+    uint256 public constant RATE_WINDOW_SIZE = 1 hours;
+    uint256 public rateLimit;
+
+    event TierUpdated(uint256 index, uint256 minVolume, uint256 discountBps);
+    event FeeCharged(address indexed account, uint256 amount);
+
+    constructor(address authorizer_, uint256 rateLimit_) {
+        authorizer = authorizer_;
+        rateLimit = rateLimit_;
+    }
+
+    /// @notice Adds a new fee tier. Requires a signature from `authorizer`
+    /// over the tier parameters instead of bespoke inline access control.
+    function setTier(uint256 minVolume, uint256 discountBps, bytes calldata signature) external {
+        bytes32 digest = keccak256(abi.encode(address(this), minVolume, discountBps));
+        if (DelegateLogicLib.recoverAuthorizer(digest, signature) != authorizer) revert NotAuthorizer();
+
+        tiers.push(DelegateLogicLib.Tier({minVolume: minVolume, discountBps: discountBps}));
+        emit TierUpdated(tiers.length - 1, minVolume, discountBps);
+    }
+
+    /// @notice Charges a batch of raw fees for `msg.sender`, applying their
+    /// resolved tier discount and enforcing the rolling rate limit.
+    function chargeBatch(uint256[] calldata rawFees) external returns (uint256 total) {
+        (bool allowed, uint256 newUsage) = DelegateLogicLib.checkRateLimit(
+            rateWindowUsage[msg.sender],
+            block.timestamp - rateWindowStart[msg.sender],
+            RATE_WINDOW_SIZE,
+            rateLimit,
+            rawFees.length
+        );
+        if (!allowed) revert RateLimited();
+
+        rateWindowUsage[msg.sender] = newUsage;
+        rateWindowStart[msg.sender] = block.timestamp;
+
+        total = DelegateLogicLib.computeBatchFee(tiers, cumulativeVolume[msg.sender], rawFees);
+        cumulativeVolume[msg.sender] += total;
+
+        emit FeeCharged(msg.sender, total);
+    }
+
+    function tierCount() external view returns (uint256) {
+        return tiers.length;
+    }
+}

--- a/contracts/storage/YulArrayUtils.sol
+++ b/contracts/storage/YulArrayUtils.sol
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title YulArrayUtils
+/// @notice Generic Yul-assembly helper for O(1) "swap-and-pop" removal from
+/// storage arrays, replacing Solidity's default `array[i] = array[array.length - 1];
+/// array.pop();` pattern with direct opcode-level `sload`/`sstore` access.
+/// @dev Solidity already implements swap-and-pop this way under the hood for
+/// dynamic storage arrays, but the high-level version pays for an extra
+/// bounds-checked `sload`/`sstore` round trip per step and cannot be reused
+/// across value types without duplicating the logic. This library exposes
+/// the same operation as a single assembly block per element type, callable
+/// directly on any `storage` array reference via `arr.slot`.
+library YulArrayUtils {
+    /// @dev Thrown when `index` is not a valid element of the array.
+    error IndexOutOfBounds();
+
+    /// @notice Removes the element at `index` from `arr` in O(1) time by
+    /// moving the last element into `index`'s slot and shrinking the array,
+    /// instead of shifting every subsequent element.
+    /// @param arr The storage array to mutate.
+    /// @param index The index to remove.
+    function removeAtIndex(uint256[] storage arr, uint256 index) internal {
+        uint256 length = arr.length;
+        if (index >= length) revert IndexOutOfBounds();
+
+        assembly {
+            // Dynamic storage arrays store their length at `arr.slot` and
+            // their elements starting at `keccak256(arr.slot)`.
+            mstore(0x00, arr.slot)
+            let baseSlot := keccak256(0x00, 0x20)
+
+            let lastIndex := sub(length, 1)
+            let lastSlot := add(baseSlot, lastIndex)
+            let lastValue := sload(lastSlot)
+
+            // Move the last element into the removed slot (no-op if
+            // `index == lastIndex`, i.e. removing the tail element).
+            sstore(add(baseSlot, index), lastValue)
+
+            // Zero out the now-vacated final slot to claim the storage
+            // refund, then shrink the array length.
+            sstore(lastSlot, 0)
+            sstore(arr.slot, lastIndex)
+        }
+    }
+
+    /// @notice `address[]` overload of {removeAtIndex}, identical semantics.
+    /// @param arr The storage array to mutate.
+    /// @param index The index to remove.
+    function removeAtIndex(address[] storage arr, uint256 index) internal {
+        uint256 length = arr.length;
+        if (index >= length) revert IndexOutOfBounds();
+
+        assembly {
+            mstore(0x00, arr.slot)
+            let baseSlot := keccak256(0x00, 0x20)
+
+            let lastIndex := sub(length, 1)
+            let lastSlot := add(baseSlot, lastIndex)
+            let lastValue := sload(lastSlot)
+
+            sstore(add(baseSlot, index), lastValue)
+            sstore(lastSlot, 0)
+            sstore(arr.slot, lastIndex)
+        }
+    }
+}
+
+/// @title YulArrayUtilsHarness
+/// @notice Thin, testable wrapper so {YulArrayUtils}'s internal functions can
+/// be exercised via external calls from tests.
+contract YulArrayUtilsHarness {
+    using YulArrayUtils for uint256[];
+    using YulArrayUtils for address[];
+
+    uint256[] private numbers;
+    address[] private addresses;
+
+    function pushNumber(uint256 value) external {
+        numbers.push(value);
+    }
+
+    function pushAddress(address value) external {
+        addresses.push(value);
+    }
+
+    function removeNumberAt(uint256 index) external {
+        numbers.removeAtIndex(index);
+    }
+
+    function removeAddressAt(uint256 index) external {
+        addresses.removeAtIndex(index);
+    }
+
+    function getNumbers() external view returns (uint256[] memory) {
+        return numbers;
+    }
+
+    function getAddresses() external view returns (address[] memory) {
+        return addresses;
+    }
+
+    function numbersLength() external view returns (uint256) {
+        return numbers.length;
+    }
+
+    function addressesLength() external view returns (uint256) {
+        return addresses.length;
+    }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,8 @@
+[profile.default]
+src = "contracts"
+test = "test"
+out = "out"
+libs = []
+solc_version = "0.8.20"
+optimizer = true
+optimizer_runs = 1000

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,0 +1,23 @@
+import { HardhatUserConfig } from "hardhat/config";
+import "@nomicfoundation/hardhat-toolbox";
+
+const config: HardhatUserConfig = {
+  solidity: {
+    version: "0.8.20",
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 1000,
+      },
+    },
+  },
+  paths: {
+    sources: "./contracts",
+    tests: "./test",
+  },
+  mocha: {
+    timeout: 40000,
+  },
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test:cov": "jest --coverage",
     "test:e2e": "jest --config ./apps/api/test/jest-e2e.json",
     "test:regression": "jest --testPathPattern='tests/regression/security/stellar/regression.spec' --no-coverage --verbose",
-    "bench:gas-comparator": "ts-node tests/benchmarks/gas-comparator.ts tests/benchmarks/fixtures"
+    "bench:gas-comparator": "ts-node tests/benchmarks/gas-comparator.ts tests/benchmarks/fixtures",
+    "test:contracts": "hardhat test"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",
@@ -35,9 +36,14 @@
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",
+    "@nomicfoundation/hardhat-toolbox": "^5.0.0",
+    "@types/chai": "^4.3.16",
     "@types/glob": "^8.1.0",
     "@types/jest": "^29.5.2",
+    "@types/mocha": "^10.0.6",
     "@types/node": "^20.3.1",
+    "chai": "^4.5.0",
+    "hardhat": "^2.22.5",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.42.0",

--- a/packages/cli/src/analyzers/memory_profiler.rs
+++ b/packages/cli/src/analyzers/memory_profiler.rs
@@ -1,0 +1,222 @@
+//! EVM memory allocation profiler.
+//!
+//! Tracks how far a function pushes the free memory pointer (the word at
+//! `0x40`) over the course of its execution and flags functions whose
+//! cumulative allocations trip the EVM's quadratic memory-expansion cost:
+//!
+//! ```text
+//! C_mem(a) = 3a + a^2 / 512
+//! ```
+//!
+//! where `a` is memory size in 32-byte words. Because the second term grows
+//! quadratically, large single allocations (or many small ones inside a
+//! loop) can produce gas spikes that are easy to miss when eyeballing
+//! Solidity source. This module gives GasGuard's static/dynamic analysis
+//! passes a way to compute that cost ahead of deployment.
+
+use std::collections::HashMap;
+
+/// EVM word size in bytes.
+const EVM_WORD_SIZE: u64 = 32;
+
+/// Solidity's conventional starting free-memory-pointer value: the two
+/// reserved scratch words (`0x00`-`0x3f`) plus the `0x40` slot itself.
+const INITIAL_FREE_MEMORY_OFFSET: u64 = 0x80;
+
+/// Allocations pushing a function's cumulative footprint past this many
+/// bytes are flagged as a critical quadratic-expansion risk.
+pub const CRITICAL_ALLOCATION_THRESHOLD_BYTES: u64 = 1024;
+
+/// Severity of a memory-profiling finding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemorySeverity {
+    Info,
+    Warning,
+    Critical,
+}
+
+/// A single recorded free-memory-pointer bump.
+#[derive(Debug, Clone)]
+pub struct MemoryAllocation {
+    pub function_name: String,
+    pub size_bytes: u64,
+    /// Free-memory-pointer value immediately after this allocation.
+    pub cumulative_offset: u64,
+}
+
+/// A flagged function whose memory footprint is expensive or risky.
+#[derive(Debug, Clone)]
+pub struct MemoryWarning {
+    pub function_name: String,
+    pub severity: MemorySeverity,
+    pub allocated_bytes: u64,
+    pub expansion_gas_cost: u64,
+    pub message: String,
+}
+
+/// Tracks free-memory-pointer growth across a sequence of allocation steps
+/// (a static walk of a function's allocation sites, or a dynamic execution
+/// trace) and computes EVM memory-expansion gas costs from it.
+#[derive(Debug, Default)]
+pub struct MemoryProfiler {
+    free_memory_pointer: u64,
+    allocations: Vec<MemoryAllocation>,
+}
+
+impl MemoryProfiler {
+    pub fn new() -> Self {
+        Self {
+            free_memory_pointer: INITIAL_FREE_MEMORY_OFFSET,
+            allocations: Vec::new(),
+        }
+    }
+
+    /// Computes `C_mem(a) = 3a + a^2 / 512` for a region of `size_bytes`,
+    /// rounding up to a whole number of 32-byte words first.
+    pub fn memory_expansion_gas_cost(size_bytes: u64) -> u64 {
+        let words = Self::bytes_to_words(size_bytes);
+        3 * words + (words * words) / 512
+    }
+
+    fn bytes_to_words(size_bytes: u64) -> u64 {
+        (size_bytes + EVM_WORD_SIZE - 1) / EVM_WORD_SIZE
+    }
+
+    /// Records the free memory pointer advancing by `size_bytes` for
+    /// `function_name`, simulating a single allocation step. Returns the
+    /// *marginal* gas cost of this specific expansion (the quadratic
+    /// formula evaluated at the new high-water mark minus at the old one),
+    /// which is what the EVM actually charges per `MSTORE`/`CALLDATACOPY`
+    /// touching new memory.
+    pub fn record_allocation(&mut self, function_name: &str, size_bytes: u64) -> u64 {
+        let cost_before = Self::memory_expansion_gas_cost(self.active_bytes());
+        self.free_memory_pointer += size_bytes;
+        let cost_after = Self::memory_expansion_gas_cost(self.active_bytes());
+
+        self.allocations.push(MemoryAllocation {
+            function_name: function_name.to_string(),
+            size_bytes,
+            cumulative_offset: self.free_memory_pointer,
+        });
+
+        cost_after.saturating_sub(cost_before)
+    }
+
+    /// Bytes actively allocated so far (free memory pointer minus its
+    /// starting offset).
+    pub fn active_bytes(&self) -> u64 {
+        self.free_memory_pointer - INITIAL_FREE_MEMORY_OFFSET
+    }
+
+    /// All allocation steps recorded so far.
+    pub fn allocations(&self) -> &[MemoryAllocation] {
+        &self.allocations
+    }
+
+    /// Aggregates recorded allocations per function and flags any whose
+    /// total footprint exceeds {CRITICAL_ALLOCATION_THRESHOLD_BYTES}.
+    pub fn flag_warnings(&self) -> Vec<MemoryWarning> {
+        let mut totals: HashMap<&str, u64> = HashMap::new();
+        for allocation in &self.allocations {
+            *totals.entry(allocation.function_name.as_str()).or_insert(0) += allocation.size_bytes;
+        }
+
+        let mut warnings: Vec<MemoryWarning> = totals
+            .into_iter()
+            .filter(|(_, total_bytes)| *total_bytes > CRITICAL_ALLOCATION_THRESHOLD_BYTES)
+            .map(|(function_name, total_bytes)| MemoryWarning {
+                function_name: function_name.to_string(),
+                severity: MemorySeverity::Critical,
+                allocated_bytes: total_bytes,
+                expansion_gas_cost: Self::memory_expansion_gas_cost(total_bytes),
+                message: format!(
+                    "function '{function_name}' allocates {total_bytes} bytes of memory (> {CRITICAL_ALLOCATION_THRESHOLD_BYTES} byte threshold); quadratic memory expansion may cause unexpected gas spikes"
+                ),
+            })
+            .collect();
+
+        warnings.sort_by(|a, b| b.allocated_bytes.cmp(&a.allocated_bytes));
+        warnings
+    }
+
+    /// Resets the profiler to analyze a fresh execution/function.
+    pub fn reset(&mut self) {
+        self.free_memory_pointer = INITIAL_FREE_MEMORY_OFFSET;
+        self.allocations.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formula_matches_known_checkpoints() {
+        // a = 0 words -> 0 gas.
+        assert_eq!(MemoryProfiler::memory_expansion_gas_cost(0), 0);
+        // a = 1 word (32 bytes) -> 3*1 + 1/512 = 3.
+        assert_eq!(MemoryProfiler::memory_expansion_gas_cost(32), 3);
+        // a = 32 words (1024 bytes) -> 3*32 + 32*32/512 = 96 + 2 = 98.
+        assert_eq!(MemoryProfiler::memory_expansion_gas_cost(1024), 98);
+        // a = 512 words (16384 bytes) -> 3*512 + 512*512/512 = 1536 + 512 = 2048.
+        assert_eq!(MemoryProfiler::memory_expansion_gas_cost(16384), 2048);
+    }
+
+    #[test]
+    fn record_allocation_returns_marginal_cost() {
+        let mut profiler = MemoryProfiler::new();
+
+        // First 32-byte allocation from an empty state costs C_mem(32) - C_mem(0) = 3.
+        let first = profiler.record_allocation("transfer", 32);
+        assert_eq!(first, 3);
+        assert_eq!(profiler.active_bytes(), 32);
+
+        // A second word-sized allocation costs C_mem(64) - C_mem(32) = 6 - 3 = 3.
+        let second = profiler.record_allocation("transfer", 32);
+        assert_eq!(second, 3);
+        assert_eq!(profiler.active_bytes(), 64);
+    }
+
+    #[test]
+    fn flags_functions_over_the_critical_threshold() {
+        let mut profiler = MemoryProfiler::new();
+        profiler.record_allocation("batchProcess", 2048);
+        profiler.record_allocation("readOnly", 64);
+
+        let warnings = profiler.flag_warnings();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].function_name, "batchProcess");
+        assert_eq!(warnings[0].severity, MemorySeverity::Critical);
+        assert_eq!(warnings[0].allocated_bytes, 2048);
+    }
+
+    #[test]
+    fn does_not_flag_functions_within_threshold() {
+        let mut profiler = MemoryProfiler::new();
+        profiler.record_allocation("smallBuffer", 512);
+
+        assert!(profiler.flag_warnings().is_empty());
+    }
+
+    #[test]
+    fn aggregates_multiple_allocations_for_the_same_function() {
+        let mut profiler = MemoryProfiler::new();
+        profiler.record_allocation("loopAppend", 600);
+        profiler.record_allocation("loopAppend", 600);
+
+        let warnings = profiler.flag_warnings();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].allocated_bytes, 1200);
+    }
+
+    #[test]
+    fn reset_clears_state() {
+        let mut profiler = MemoryProfiler::new();
+        profiler.record_allocation("f", 2048);
+        profiler.reset();
+
+        assert_eq!(profiler.active_bytes(), 0);
+        assert!(profiler.allocations().is_empty());
+        assert!(profiler.flag_warnings().is_empty());
+    }
+}

--- a/packages/cli/src/analyzers/mod.rs
+++ b/packages/cli/src/analyzers/mod.rs
@@ -1,0 +1,3 @@
+pub mod memory_profiler;
+
+pub use memory_profiler::{MemoryProfiler, MemorySeverity, MemoryWarning};

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -2,6 +2,8 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
+pub mod analyzers;
+
 pub fn collect_scannable_files(dir_path: &Path) -> Vec<PathBuf> {
     let mut files: Vec<PathBuf> = walkdir::WalkDir::new(dir_path)
         .into_iter()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,13 +50,22 @@ importers:
         version: 10.2.3(chokidar@3.6.0)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^10.0.0
-        version: 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.22))
+        version: 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@nestjs/platform-express@10.4.22)
+      '@nomicfoundation/hardhat-toolbox':
+        specifier: ^5.0.0
+        version: 5.0.0(a2365a73917159f0b0cef560382e13f5)
+      '@types/chai':
+        specifier: ^4.3.16
+        version: 4.3.20
       '@types/glob':
         specifier: ^8.1.0
         version: 8.1.0
       '@types/jest':
         specifier: ^29.5.2
         version: 29.5.14
+      '@types/mocha':
+        specifier: ^10.0.6
+        version: 10.0.10
       '@types/node':
         specifier: ^20.3.1
         version: 20.19.33
@@ -66,6 +75,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^6.0.0
         version: 6.21.0(eslint@8.57.1)(typescript@5.9.3)
+      chai:
+        specifier: ^4.5.0
+        version: 4.5.0
       eslint:
         specifier: ^8.42.0
         version: 8.57.1
@@ -78,6 +90,9 @@ importers:
       glob:
         specifier: ^13.0.6
         version: 13.0.6
+      hardhat:
+        specifier: ^2.22.5
+        version: 2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
       husky:
         specifier: ^8.0.0
         version: 8.0.3
@@ -119,10 +134,10 @@ importers:
         version: 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)
       '@nestjs/swagger':
         specifier: ^7.1.0
-        version: 7.4.2(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)
+        version: 7.4.2(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)
       '@nestjs/throttler':
         specifier: ^5.1.0
-        version: 5.2.0(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)
+        version: 5.2.0(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(reflect-metadata@0.2.2)
       bullmq:
         specifier: ^5.1.0
         version: 5.69.3
@@ -150,7 +165,7 @@ importers:
         version: 10.2.3(chokidar@3.6.0)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^10.4.22
-        version: 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22))
+        version: 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@nestjs/platform-express@10.4.22)
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.25
@@ -195,13 +210,13 @@ importers:
         version: 11.1.14(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.14)
       '@nestjs/schedule':
         specifier: ^4.0.2
-        version: 4.1.2(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.14(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.14)(reflect-metadata@0.2.2)(rxjs@7.8.2))
+        version: 4.1.2(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.14)
       '@nestjs/swagger':
         specifier: ^8.1.0
-        version: 8.1.1(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.14(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.14)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)
+        version: 8.1.1(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.14)(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)
       '@nestjs/typeorm':
         specifier: ^11.0.0
-        version: 11.0.0(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.14(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.14)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.11.0)(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.11)(typescript@5.9.3)))
+        version: 11.0.0(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.14)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.11.0)(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.11)(typescript@5.9.3)))
       bcrypt:
         specifier: ^5.1.1
         version: 5.1.1
@@ -247,10 +262,10 @@ importers:
         version: 11.0.9(chokidar@4.0.3)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.0.0
-        version: 11.1.14(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.14(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.14)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.14(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.14))
+        version: 11.1.14(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.14)(@nestjs/platform-express@11.1.14)
       '@nomicfoundation/hardhat-toolbox':
         specifier: ^6.1.0
-        version: 6.1.2(@nomicfoundation/hardhat-chai-matchers@2.1.2(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@3.2.0))(chai@4.5.0)(ethers@6.16.0)(hardhat@3.2.0))(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@3.2.0))(@nomicfoundation/hardhat-ignition-ethers@0.15.17(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@3.2.0))(@nomicfoundation/hardhat-ignition@0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@3.2.0))(hardhat@3.2.0))(@nomicfoundation/ignition-core@0.15.15)(ethers@6.16.0)(hardhat@3.2.0))(@nomicfoundation/hardhat-network-helpers@1.1.2(hardhat@3.2.0))(@nomicfoundation/hardhat-verify@2.1.3(hardhat@3.2.0))(@typechain/ethers-v6@0.5.1(ethers@6.16.0)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3))(@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.16.0)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3))(ethers@6.16.0)(hardhat@3.2.0)(typechain@8.3.2(typescript@5.9.3)))(@types/chai@4.3.20)(@types/mocha@10.0.10)(@types/node@22.19.11)(chai@4.5.0)(ethers@6.16.0)(hardhat-gas-reporter@2.3.0(hardhat@3.2.0)(typescript@5.9.3)(zod@3.25.76))(hardhat@3.2.0)(solidity-coverage@0.8.17(hardhat@3.2.0))(ts-node@10.9.2(@types/node@22.19.11)(typescript@5.9.3))(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)
+        version: 6.1.2(a9bd8464ba0383d2bc60e556ee92545a)
       '@types/bcrypt':
         specifier: ^5.0.2
         version: 5.0.2
@@ -384,6 +399,19 @@ importers:
     devDependencies:
       typescript:
         specifier: ^5.3.0
+        version: 5.9.3
+
+  libs/gas-evaluator:
+    dependencies:
+      axios:
+        specifier: ^1.15.2
+        version: 1.16.1
+    devDependencies:
+      '@types/node':
+        specifier: ^20.3.1
+        version: 20.19.33
+      typescript:
+        specifier: ^5.1.3
         version: 5.9.3
 
   libs/testing:
@@ -905,9 +933,18 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  '@ethereumjs/rlp@5.0.2':
+    resolution: {integrity: sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@ethereumjs/util@8.1.0':
     resolution: {integrity: sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==}
     engines: {node: '>=14'}
+
+  '@ethereumjs/util@9.1.0':
+    resolution: {integrity: sha512-XBEKsYqLGXLah9PNJbgdkigthkG7TAGvlD/sH12beMXEyHDyigfcbdvHhmLyDWgDyOJn4QwiQUaF7yeuhnjdog==}
+    engines: {node: '>=18'}
 
   '@ethersproject/abi@5.8.0':
     resolution: {integrity: sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q==}
@@ -1666,6 +1703,9 @@ packages:
     resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/hashes@1.2.0':
+    resolution: {integrity: sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==}
+
   '@noble/hashes@1.3.2':
     resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
     engines: {node: '>= 16'}
@@ -1682,6 +1722,9 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/secp256k1@1.7.1':
+    resolution: {integrity: sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1694,32 +1737,64 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.23':
+    resolution: {integrity: sha512-Amh7mRoDzZyJJ4efqoePqdoZOzharmSOttZuJDlVE5yy07BoE8hL6ZRpa5fNYn0LCqn/KoWs8OHANWxhKDGhvQ==}
+    engines: {node: '>= 20'}
+
   '@nomicfoundation/edr-darwin-arm64@0.12.0-next.28':
     resolution: {integrity: sha512-fJsQ8enlgp4Sky98jHcAFXXmb3EYNoYlwtGlmfoYjDsIeL74a2lozNzyo55CtduHD/sugffjtyF0nDyxZEdwMg==}
+    engines: {node: '>= 20'}
+
+  '@nomicfoundation/edr-darwin-x64@0.12.0-next.23':
+    resolution: {integrity: sha512-9wn489FIQm7m0UCD+HhktjWx6vskZzeZD9oDc2k9ZvbBzdXwPp5tiDqUBJ+eQpByAzCDfteAJwRn2lQCE0U+Iw==}
     engines: {node: '>= 20'}
 
   '@nomicfoundation/edr-darwin-x64@0.12.0-next.28':
     resolution: {integrity: sha512-QST3PPJPejfRJhxThR5CoCxQAfIty0n8k40JtI+wLwKGCDT86JRKkJ3AaXPM1a72nUqMYoQK+gzQyA11zZGd4Q==}
     engines: {node: '>= 20'}
 
+  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.23':
+    resolution: {integrity: sha512-nlk5EejSzEUfEngv0Jkhqq3/wINIfF2ED9wAofc22w/V1DV99ASh9l3/e/MIHOQFecIZ9MDqt0Em9/oDyB1Uew==}
+    engines: {node: '>= 20'}
+
   '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.28':
     resolution: {integrity: sha512-sj4p6jeQfkiePxn1goZFZzz7V0SVFfZDH6ngPileQcAoFBWHKqi17UOG4IZ4NFpjYmDCcdrUWDNRbxC7OhgEqQ==}
+    engines: {node: '>= 20'}
+
+  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.23':
+    resolution: {integrity: sha512-SJuPBp3Rc6vM92UtVTUxZQ/QlLhLfwTftt2XUiYohmGKB3RjGzpgduEFMCA0LEnucUckU6UHrJNFHiDm77C4PQ==}
     engines: {node: '>= 20'}
 
   '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.28':
     resolution: {integrity: sha512-d0hV02jMTozPEqRF3PO65Xi6/RqN5EywU5KaiDMcO+8b0nk+pJZ6VdcugRgv3lMMJbM/sP3LDFQn2eoOhalp7w==}
     engines: {node: '>= 20'}
 
+  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.23':
+    resolution: {integrity: sha512-NU+Qs3u7Qt6t3bJFdmmjd5CsvgI2bPPzO31KifM2Ez96/jsXYho5debtTQnimlb5NAqiHTSlxjh/F8ROcptmeQ==}
+    engines: {node: '>= 20'}
+
   '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.28':
     resolution: {integrity: sha512-x3z4xbmCtSyZZg9MOhHcw1DOscngj50KK+6ZG0HKkGEbZ7WvDB9BnmRFEWo1rvIM+gqIcZvUBJbpLIdkA/BQYw==}
+    engines: {node: '>= 20'}
+
+  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.23':
+    resolution: {integrity: sha512-F78fZA2h6/ssiCSZOovlgIu0dUeI7ItKPsDDF3UUlIibef052GCXmliMinC90jVPbrjUADMd1BUwjfI0Z8OllQ==}
     engines: {node: '>= 20'}
 
   '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.28':
     resolution: {integrity: sha512-CKGcvP7enTo7gTXVxQiR8txPDOTNqS+wPLPkKXFzQBuVJ0FDj8eKIMRlZaw3Wbcd8QObaAKmKH7KzHVO5zzXmQ==}
     engines: {node: '>= 20'}
 
+  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.23':
+    resolution: {integrity: sha512-IfJZQJn7d/YyqhmguBIGoCKjE9dKjbu6V6iNEPApfwf5JyyjHYyyfkLU4rf7hygj57bfH4sl1jtQ6r8HnT62lw==}
+    engines: {node: '>= 20'}
+
   '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.28':
     resolution: {integrity: sha512-QAzb9dZGwOU7Ee2N96dvdSLiUMmjlPVxgLqTKsQbkibcBZ9I+Zs8TGisGUZsDccrbUcR4wDv8S9tD1EM9fEs/g==}
+    engines: {node: '>= 20'}
+
+  '@nomicfoundation/edr@0.12.0-next.23':
+    resolution: {integrity: sha512-F2/6HZh8Q9RsgkOIkRrckldbhPjIZY7d4mT9LYuW68miwGQ5l7CkAgcz9fRRiurA0+YJhtsbx/EyrD9DmX9BOw==}
     engines: {node: '>= 20'}
 
   '@nomicfoundation/edr@0.12.0-next.28':
@@ -1762,6 +1837,28 @@ packages:
     resolution: {integrity: sha512-p7HaUVDbLj7ikFivQVNhnfMHUBgiHYMwQWvGn9AriieuopGOELIrwj2KjyM2a6z70zai5YKO264Vwz+3UFJZPQ==}
     peerDependencies:
       hardhat: ^2.26.0
+
+  '@nomicfoundation/hardhat-toolbox@5.0.0':
+    resolution: {integrity: sha512-FnUtUC5PsakCbwiVNsqlXVIWG5JIb5CEZoSXbJUsEBun22Bivx2jhF1/q9iQbzuaGpJKFQyOhemPB2+XlEE6pQ==}
+    peerDependencies:
+      '@nomicfoundation/hardhat-chai-matchers': ^2.0.0
+      '@nomicfoundation/hardhat-ethers': ^3.0.0
+      '@nomicfoundation/hardhat-ignition-ethers': ^0.15.0
+      '@nomicfoundation/hardhat-network-helpers': ^1.0.0
+      '@nomicfoundation/hardhat-verify': ^2.0.0
+      '@typechain/ethers-v6': ^0.5.0
+      '@typechain/hardhat': ^9.0.0
+      '@types/chai': ^4.2.0
+      '@types/mocha': '>=9.1.0'
+      '@types/node': '>=18.0.0'
+      chai: ^4.2.0
+      ethers: ^6.4.0
+      hardhat: ^2.11.0
+      hardhat-gas-reporter: ^1.0.8
+      solidity-coverage: ^0.8.1
+      ts-node: '>=8.0.0'
+      typechain: ^8.3.0
+      typescript: '>=4.5.0'
 
   '@nomicfoundation/hardhat-toolbox@6.1.2':
     resolution: {integrity: sha512-xKL2r43GC/UIcQzmtFSmj3L4KqLSQ4fK+kyUw0vbIp94nV+9o2ZkI1s3znB8EKXqitt9ClXo0qcKj9RKOFjqPQ==}
@@ -1913,36 +2010,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.2':
     resolution: {integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.2':
     resolution: {integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.2':
     resolution: {integrity: sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.2':
     resolution: {integrity: sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.2':
     resolution: {integrity: sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.2':
     resolution: {integrity: sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==}
@@ -1979,11 +2082,17 @@ packages:
   '@scure/base@1.2.6':
     resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
 
+  '@scure/bip32@1.1.5':
+    resolution: {integrity: sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==}
+
   '@scure/bip32@1.4.0':
     resolution: {integrity: sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==}
 
   '@scure/bip32@1.7.0':
     resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
+
+  '@scure/bip39@1.1.1':
+    resolution: {integrity: sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==}
 
   '@scure/bip39@1.3.0':
     resolution: {integrity: sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==}
@@ -1991,9 +2100,37 @@ packages:
   '@scure/bip39@1.6.0':
     resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
+  '@sentry/core@5.30.0':
+    resolution: {integrity: sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==}
+    engines: {node: '>=6'}
+
   '@sentry/core@9.47.1':
     resolution: {integrity: sha512-KX62+qIt4xgy8eHKHiikfhz2p5fOciXd0Cl+dNzhgPFq8klq4MGMNaf148GB3M/vBqP4nw/eFvRMAayFCgdRQw==}
     engines: {node: '>=18'}
+
+  '@sentry/hub@5.30.0':
+    resolution: {integrity: sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==}
+    engines: {node: '>=6'}
+
+  '@sentry/minimal@5.30.0':
+    resolution: {integrity: sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==}
+    engines: {node: '>=6'}
+
+  '@sentry/node@5.30.0':
+    resolution: {integrity: sha512-Br5oyVBF0fZo6ZS9bxbJZG4ApAjRqAnqFFurMVJJdunNb80brh7a5Qva2kjhm+U6r9NJAB5OmDyPkA1Qnt+QVg==}
+    engines: {node: '>=6'}
+
+  '@sentry/tracing@5.30.0':
+    resolution: {integrity: sha512-dUFowCr0AIMwiLD7Fs314Mdzcug+gBVo/+NCMyDw8tFxJkwWAKl7Qa2OZxLQ0ZHjakcj1hNKfCQJ9rhyfOl4Aw==}
+    engines: {node: '>=6'}
+
+  '@sentry/types@5.30.0':
+    resolution: {integrity: sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw==}
+    engines: {node: '>=6'}
+
+  '@sentry/utils@5.30.0':
+    resolution: {integrity: sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==}
+    engines: {node: '>=6'}
 
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
@@ -2029,6 +2166,7 @@ packages:
   '@stellar/stellar-base@15.0.0':
     resolution: {integrity: sha512-XQhxUr9BYiEcFcgc4oWcCMR9QJCny/GmmGsuwPKf/ieIcOeb5149KLHYx9mJCA0ea8QbucR2/GzV58QbXOTxQA==}
     engines: {node: '>=20.0.0'}
+    deprecated: This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.
 
   '@stellar/stellar-sdk@15.1.0':
     resolution: {integrity: sha512-GsJUcWx2yboVzYdhTe/LHS3V1wVLSHkUkglC5bBoYWGJt31vzIhbSGno60NP9CdCTNkLJdnrsLJ63oA58Zvh5A==}
@@ -2485,41 +2623,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2661,6 +2807,10 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
 
+  aggregate-error@3.1.0:
+    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
+    engines: {node: '>=8'}
+
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -2705,6 +2855,9 @@ packages:
   amdefine@1.0.1:
     resolution: {integrity: sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==}
     engines: {node: '>=0.4.2'}
+
+  ansi-align@3.0.1:
+    resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -2936,6 +3089,10 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
+  boxen@5.1.2:
+    resolution: {integrity: sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==}
+    engines: {node: '>=10'}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -3106,6 +3263,9 @@ packages:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
 
+  ci-info@2.0.0:
+    resolution: {integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==}
+
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
@@ -3129,6 +3289,14 @@ packages:
 
   class-validator@0.14.3:
     resolution: {integrity: sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==}
+
+  clean-stack@2.2.0:
+    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
+    engines: {node: '>=6'}
+
+  cli-boxes@2.2.1:
+    resolution: {integrity: sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==}
+    engines: {node: '>=6'}
 
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
@@ -3201,6 +3369,9 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
+  command-exists@1.2.9:
+    resolution: {integrity: sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==}
+
   command-line-args@5.2.1:
     resolution: {integrity: sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==}
     engines: {node: '>=4.0.0'}
@@ -3223,6 +3394,10 @@ packages:
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
 
   comment-json@4.2.5:
     resolution: {integrity: sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw==}
@@ -3273,6 +3448,10 @@ packages:
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
+
+  cookie@0.4.2:
+    resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
+    engines: {node: '>= 0.6'}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -3476,6 +3655,10 @@ packages:
 
   diff@5.2.2:
     resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
+    engines: {node: '>=0.3.1'}
+
+  diff@7.0.0:
+    resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
     engines: {node: '>=0.3.1'}
 
   difflib@0.2.4:
@@ -3733,6 +3916,9 @@ packages:
   ethereum-cryptography@0.1.3:
     resolution: {integrity: sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==}
 
+  ethereum-cryptography@1.2.0:
+    resolution: {integrity: sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==}
+
   ethereum-cryptography@2.2.1:
     resolution: {integrity: sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==}
 
@@ -3956,6 +4142,9 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
+  fp-ts@1.19.3:
+    resolution: {integrity: sha512-H5KQDspykdHuztLTg+ajGN0Z2qUjcEf3Ybxc6hLt0k7/zPkn29XnKnxlBPyW2XIddWrGaJBzBl4VLYOtk39yZg==}
+
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
@@ -4148,6 +4337,18 @@ packages:
     peerDependencies:
       hardhat: ^2.16.0
 
+  hardhat@2.29.0:
+    resolution: {integrity: sha512-tsj5mCSjDCFOhGfBl4vwqDEcwdlES9VUzRWfdrwvEVhus6D8W6u+WfUKRLLwFhKGS/8lKPoXGsjYWPXl3CCpOg==}
+    hasBin: true
+    peerDependencies:
+      ts-node: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      ts-node:
+        optional: true
+      typescript:
+        optional: true
+
   hardhat@3.2.0:
     resolution: {integrity: sha512-1s5mE1OEx4ksnv+9bHRfzfWxlzI77mQ5cHbSNRxZp2DvpVOC41qSoIDfwqwvb3I2JqUVd0TBUgN/Ypco6sabkQ==}
     hasBin: true
@@ -4257,6 +4458,9 @@ packages:
   immer@11.1.8:
     resolution: {integrity: sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==}
 
+  immutable@4.3.9:
+    resolution: {integrity: sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -4269,6 +4473,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -4295,6 +4503,9 @@ packages:
   interpret@1.4.0:
     resolution: {integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==}
     engines: {node: '>= 0.10'}
+
+  io-ts@1.10.4:
+    resolution: {integrity: sha512-b23PteSnYXSONJ6JQXRAlvJhuw8KOtkqa87W4wDtvMrud/DTJd5X+NpOOI+O/zZwVq6v0VLAaJ+1EDViKEuN9g==}
 
   ioredis@5.11.0:
     resolution: {integrity: sha512-EZBErytyVovD8f6pDfG3Kb37N6Y3lmDA9NNj+4+IP13CzzHGeX+OyeRM2Um13khRzoBSzzL+5lVnCX8V2RLeMg==}
@@ -4837,24 +5048,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -4978,6 +5193,9 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lru_map@0.3.3:
+    resolution: {integrity: sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==}
+
   lucide-react@1.17.0:
     resolution: {integrity: sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==}
     peerDependencies:
@@ -5033,6 +5251,10 @@ packages:
   memfs@3.5.3:
     resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
     engines: {node: '>= 4.0.0'}
+
+  memorystream@0.3.1:
+    resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
+    engines: {node: '>= 0.10.0'}
 
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
@@ -5152,9 +5374,17 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  mnemonist@0.38.5:
+    resolution: {integrity: sha512-bZTFT5rrPKtPJxj8KSV0WkPyNxl72vQepqqVUAW2ARUpUSF2qXMB6jZj7hW5/k7C1rtpzqbD/IIbJwLXUjCHeg==}
+
   mocha@10.8.2:
     resolution: {integrity: sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==}
     engines: {node: '>= 14.0.0'}
+    hasBin: true
+
+  mocha@11.7.6:
+    resolution: {integrity: sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
 
   motion-dom@12.40.0:
@@ -5300,6 +5530,9 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
+  obliterator@2.0.5:
+    resolution: {integrity: sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -5352,6 +5585,10 @@ packages:
 
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  p-map@4.0.0:
+    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
     engines: {node: '>=10'}
 
   p-map@7.0.4:
@@ -5481,10 +5718,6 @@ packages:
 
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
-    engines: {node: '>=12'}
-
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
   picomatch@4.0.4:
@@ -5733,6 +5966,9 @@ packages:
   resolve@1.1.7:
     resolution: {integrity: sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg==}
 
+  resolve@1.17.0:
+    resolution: {integrity: sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==}
+
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
@@ -5818,6 +6054,10 @@ packages:
   secp256k1@4.0.4:
     resolution: {integrity: sha512-6JfvwvjUOn8F/jUoBY2Q1v5WY5XS+rj8qSe0v8Y4ezH4InLgTEeOOPQsRll9OV429Pvo6BCHGavIyJfr3TAhsw==}
     engines: {node: '>=18.0.0'}
+
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -5915,6 +6155,11 @@ packages:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
     engines: {node: '>=10'}
 
+  solc@0.8.26:
+    resolution: {integrity: sha512-yiPQNVf5rBFHwN6SIf3TUUvVAFKcQqmSUFeq+fb6pNRCo0ZCgpYOZDi3BVoezCPIAcKrVYd/qXlBLUP9wVrZ9g==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+
   solidity-coverage@0.8.17:
     resolution: {integrity: sha512-5P8vnB6qVX9tt1MfuONtCTEaEGO/O4WuEidPHIAJjx4sktHHKhO3rFvnE0q8L30nWJPTrcqGQMT7jpE29B2qow==}
     hasBin: true
@@ -5960,6 +6205,10 @@ packages:
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
+
+  stacktrace-parser@0.1.11:
+    resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
+    engines: {node: '>=6'}
 
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
@@ -6238,11 +6487,17 @@ packages:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
 
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
   tslib@2.7.0:
     resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsort@0.0.1:
+    resolution: {integrity: sha512-Tyrf5mxF8Ofs1tNoxA13lFeZ2Zrbd6cKbuH3V+MQ5sb6DtBj5FjrXVsRWT8YvNAQTqNoz66dz1WsbigI22aEnw==}
 
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
@@ -6272,6 +6527,10 @@ packages:
   type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
+
+  type-fest@0.7.1:
+    resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
+    engines: {node: '>=8'}
 
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
@@ -6457,6 +6716,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@11.0.3:
@@ -6465,6 +6725,11 @@ packages:
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -6600,6 +6865,10 @@ packages:
   wide-align@1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
 
+  widest-line@3.1.0:
+    resolution: {integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==}
+    engines: {node: '>=8'}
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -6613,6 +6882,9 @@ packages:
 
   workerpool@6.5.1:
     resolution: {integrity: sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==}
+
+  workerpool@9.3.4:
+    resolution: {integrity: sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==}
 
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -6636,6 +6908,18 @@ packages:
   write-file-atomic@5.0.1:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  ws@7.5.13:
+    resolution: {integrity: sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.17.1:
     resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
@@ -7190,11 +7474,18 @@ snapshots:
 
   '@ethereumjs/rlp@4.0.1': {}
 
+  '@ethereumjs/rlp@5.0.2': {}
+
   '@ethereumjs/util@8.1.0':
     dependencies:
       '@ethereumjs/rlp': 4.0.1
       ethereum-cryptography: 2.2.1
       micro-ftch: 0.3.1
+
+  '@ethereumjs/util@9.1.0':
+    dependencies:
+      '@ethereumjs/rlp': 5.0.2
+      ethereum-cryptography: 2.2.1
 
   '@ethersproject/abi@5.8.0':
     dependencies:
@@ -8231,7 +8522,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nestjs/schedule@4.1.2(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.14(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.14)(reflect-metadata@0.2.2)(rxjs@7.8.2))':
+  '@nestjs/schedule@4.1.2(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.14)':
     dependencies:
       '@nestjs/common': 11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.14(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.14)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -8271,7 +8562,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/swagger@7.4.2(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)':
+  '@nestjs/swagger@7.4.2(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
       '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -8286,7 +8577,7 @@ snapshots:
       class-transformer: 0.5.1
       class-validator: 0.14.3
 
-  '@nestjs/swagger@8.1.1(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.14(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.14)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)':
+  '@nestjs/swagger@8.1.1(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.14)(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
       '@nestjs/common': 11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -8301,7 +8592,7 @@ snapshots:
       class-transformer: 0.5.1
       class-validator: 0.14.3
 
-  '@nestjs/testing@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.22))':
+  '@nestjs/testing@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@nestjs/platform-express@10.4.22)':
     dependencies:
       '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       '@nestjs/core': 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.1.14)(rxjs@7.8.2)
@@ -8309,7 +8600,7 @@ snapshots:
     optionalDependencies:
       '@nestjs/platform-express': 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.22)
 
-  '@nestjs/testing@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22))':
+  '@nestjs/testing@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@nestjs/platform-express@10.4.22)':
     dependencies:
       '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -8317,7 +8608,7 @@ snapshots:
     optionalDependencies:
       '@nestjs/platform-express': 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)
 
-  '@nestjs/testing@11.1.14(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.14(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.14)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.14(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.14))':
+  '@nestjs/testing@11.1.14(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.14)(@nestjs/platform-express@11.1.14)':
     dependencies:
       '@nestjs/common': 11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.14(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.14)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -8325,13 +8616,13 @@ snapshots:
     optionalDependencies:
       '@nestjs/platform-express': 11.1.14(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.14)
 
-  '@nestjs/throttler@5.2.0(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)':
+  '@nestjs/throttler@5.2.0(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(reflect-metadata@0.2.2)':
     dependencies:
       '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       reflect-metadata: 0.2.2
 
-  '@nestjs/typeorm@11.0.0(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.14(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.14)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.11.0)(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.11)(typescript@5.9.3)))':
+  '@nestjs/typeorm@11.0.0(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.14)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.11.0)(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.11)(typescript@5.9.3)))':
     dependencies:
       '@nestjs/common': 11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.14(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.14)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -8361,6 +8652,8 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
+  '@noble/hashes@1.2.0': {}
+
   '@noble/hashes@1.3.2': {}
 
   '@noble/hashes@1.4.0': {}
@@ -8368,6 +8661,8 @@ snapshots:
   '@noble/hashes@1.7.2': {}
 
   '@noble/hashes@1.8.0': {}
+
+  '@noble/secp256k1@1.7.1': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -8381,19 +8676,43 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.23': {}
+
   '@nomicfoundation/edr-darwin-arm64@0.12.0-next.28': {}
+
+  '@nomicfoundation/edr-darwin-x64@0.12.0-next.23': {}
 
   '@nomicfoundation/edr-darwin-x64@0.12.0-next.28': {}
 
+  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.23': {}
+
   '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.28': {}
+
+  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.23': {}
 
   '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.28': {}
 
+  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.23': {}
+
   '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.28': {}
+
+  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.23': {}
 
   '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.28': {}
 
+  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.23': {}
+
   '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.28': {}
+
+  '@nomicfoundation/edr@0.12.0-next.23':
+    dependencies:
+      '@nomicfoundation/edr-darwin-arm64': 0.12.0-next.23
+      '@nomicfoundation/edr-darwin-x64': 0.12.0-next.23
+      '@nomicfoundation/edr-linux-arm64-gnu': 0.12.0-next.23
+      '@nomicfoundation/edr-linux-arm64-musl': 0.12.0-next.23
+      '@nomicfoundation/edr-linux-x64-gnu': 0.12.0-next.23
+      '@nomicfoundation/edr-linux-x64-musl': 0.12.0-next.23
+      '@nomicfoundation/edr-win32-x64-msvc': 0.12.0-next.23
 
   '@nomicfoundation/edr@0.12.0-next.28':
     dependencies:
@@ -8404,6 +8723,17 @@ snapshots:
       '@nomicfoundation/edr-linux-x64-gnu': 0.12.0-next.28
       '@nomicfoundation/edr-linux-x64-musl': 0.12.0-next.28
       '@nomicfoundation/edr-win32-x64-msvc': 0.12.0-next.28
+
+  '@nomicfoundation/hardhat-chai-matchers@2.1.2(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)))(chai@4.5.0)(ethers@6.16.0)(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3))':
+    dependencies:
+      '@nomicfoundation/hardhat-ethers': 3.1.3(ethers@6.16.0)(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3))
+      '@types/chai-as-promised': 7.1.8
+      chai: 4.5.0
+      chai-as-promised: 7.1.2(chai@4.5.0)
+      deep-eql: 4.1.4
+      ethers: 6.16.0
+      hardhat: 2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
+      ordinal: 1.0.3
 
   '@nomicfoundation/hardhat-chai-matchers@2.1.2(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@3.2.0))(chai@4.5.0)(ethers@6.16.0)(hardhat@3.2.0)':
     dependencies:
@@ -8422,6 +8752,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3))':
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      ethers: 6.16.0
+      hardhat: 2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
+      lodash.isequal: 4.5.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@3.2.0)':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
@@ -8431,6 +8770,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@nomicfoundation/hardhat-ignition-ethers@0.15.17(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)))(@nomicfoundation/hardhat-ignition@0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)))(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)))(@nomicfoundation/ignition-core@0.15.15)(ethers@6.16.0)(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3))':
+    dependencies:
+      '@nomicfoundation/hardhat-ethers': 3.1.3(ethers@6.16.0)(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3))
+      '@nomicfoundation/hardhat-ignition': 0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)))(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3))
+      '@nomicfoundation/ignition-core': 0.15.15
+      ethers: 6.16.0
+      hardhat: 2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
+
   '@nomicfoundation/hardhat-ignition-ethers@0.15.17(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@3.2.0))(@nomicfoundation/hardhat-ignition@0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@3.2.0))(hardhat@3.2.0))(@nomicfoundation/ignition-core@0.15.15)(ethers@6.16.0)(hardhat@3.2.0)':
     dependencies:
       '@nomicfoundation/hardhat-ethers': 3.1.3(ethers@6.16.0)(hardhat@3.2.0)
@@ -8438,6 +8785,22 @@ snapshots:
       '@nomicfoundation/ignition-core': 0.15.15
       ethers: 6.16.0
       hardhat: 3.2.0
+
+  '@nomicfoundation/hardhat-ignition@0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)))(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3))':
+    dependencies:
+      '@nomicfoundation/hardhat-verify': 2.1.3(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3))
+      '@nomicfoundation/ignition-core': 0.15.15
+      '@nomicfoundation/ignition-ui': 0.15.13
+      chalk: 4.1.2
+      debug: 4.4.3(supports-color@8.1.1)
+      fs-extra: 10.1.0
+      hardhat: 2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
+      json5: 2.2.3
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   '@nomicfoundation/hardhat-ignition@0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@3.2.0))(hardhat@3.2.0)':
     dependencies:
@@ -8455,13 +8818,39 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@nomicfoundation/hardhat-network-helpers@1.1.2(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3))':
+    dependencies:
+      ethereumjs-util: 7.1.5
+      hardhat: 2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
+
   '@nomicfoundation/hardhat-network-helpers@1.1.2(hardhat@3.2.0)':
     dependencies:
       ethereumjs-util: 7.1.5
       hardhat: 3.2.0
 
-  ? '@nomicfoundation/hardhat-toolbox@6.1.2(@nomicfoundation/hardhat-chai-matchers@2.1.2(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@3.2.0))(chai@4.5.0)(ethers@6.16.0)(hardhat@3.2.0))(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@3.2.0))(@nomicfoundation/hardhat-ignition-ethers@0.15.17(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@3.2.0))(@nomicfoundation/hardhat-ignition@0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@3.2.0))(hardhat@3.2.0))(@nomicfoundation/ignition-core@0.15.15)(ethers@6.16.0)(hardhat@3.2.0))(@nomicfoundation/hardhat-network-helpers@1.1.2(hardhat@3.2.0))(@nomicfoundation/hardhat-verify@2.1.3(hardhat@3.2.0))(@typechain/ethers-v6@0.5.1(ethers@6.16.0)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3))(@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.16.0)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3))(ethers@6.16.0)(hardhat@3.2.0)(typechain@8.3.2(typescript@5.9.3)))(@types/chai@4.3.20)(@types/mocha@10.0.10)(@types/node@22.19.11)(chai@4.5.0)(ethers@6.16.0)(hardhat-gas-reporter@2.3.0(hardhat@3.2.0)(typescript@5.9.3)(zod@3.25.76))(hardhat@3.2.0)(solidity-coverage@0.8.17(hardhat@3.2.0))(ts-node@10.9.2(@types/node@22.19.11)(typescript@5.9.3))(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)'
-  : dependencies:
+  '@nomicfoundation/hardhat-toolbox@5.0.0(a2365a73917159f0b0cef560382e13f5)':
+    dependencies:
+      '@nomicfoundation/hardhat-chai-matchers': 2.1.2(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)))(chai@4.5.0)(ethers@6.16.0)(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3))
+      '@nomicfoundation/hardhat-ethers': 3.1.3(ethers@6.16.0)(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3))
+      '@nomicfoundation/hardhat-ignition-ethers': 0.15.17(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)))(@nomicfoundation/hardhat-ignition@0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)))(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)))(@nomicfoundation/ignition-core@0.15.15)(ethers@6.16.0)(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3))
+      '@nomicfoundation/hardhat-network-helpers': 1.1.2(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3))
+      '@nomicfoundation/hardhat-verify': 2.1.3(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3))
+      '@typechain/ethers-v6': 0.5.1(ethers@6.16.0)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)
+      '@typechain/hardhat': 9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.16.0)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3))(ethers@6.16.0)(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3))(typechain@8.3.2(typescript@5.9.3))
+      '@types/chai': 4.3.20
+      '@types/mocha': 10.0.10
+      '@types/node': 20.19.33
+      chai: 4.5.0
+      ethers: 6.16.0
+      hardhat: 2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
+      hardhat-gas-reporter: 2.3.0(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3))(typescript@5.9.3)(zod@3.25.76)
+      solidity-coverage: 0.8.17(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3))
+      ts-node: 10.9.2(@types/node@20.19.33)(typescript@5.9.3)
+      typechain: 8.3.2(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@nomicfoundation/hardhat-toolbox@6.1.2(a9bd8464ba0383d2bc60e556ee92545a)':
+    dependencies:
       '@nomicfoundation/hardhat-chai-matchers': 2.1.2(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@3.2.0))(chai@4.5.0)(ethers@6.16.0)(hardhat@3.2.0)
       '@nomicfoundation/hardhat-ethers': 3.1.3(ethers@6.16.0)(hardhat@3.2.0)
       '@nomicfoundation/hardhat-ignition-ethers': 0.15.17(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@3.2.0))(@nomicfoundation/hardhat-ignition@0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@3.2.0))(hardhat@3.2.0))(@nomicfoundation/ignition-core@0.15.15)(ethers@6.16.0)(hardhat@3.2.0)
@@ -8495,6 +8884,21 @@ snapshots:
       - supports-color
 
   '@nomicfoundation/hardhat-vendored@3.0.1': {}
+
+  '@nomicfoundation/hardhat-verify@2.1.3(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3))':
+    dependencies:
+      '@ethersproject/abi': 5.8.0
+      '@ethersproject/address': 5.8.0
+      cbor: 8.1.0
+      debug: 4.4.3(supports-color@8.1.1)
+      hardhat: 2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
+      lodash.clonedeep: 4.5.0
+      picocolors: 1.1.1
+      semver: 6.3.1
+      table: 6.9.0
+      undici: 5.29.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@nomicfoundation/hardhat-verify@2.1.3(hardhat@3.2.0)':
     dependencies:
@@ -8662,6 +9066,12 @@ snapshots:
 
   '@scure/base@1.2.6': {}
 
+  '@scure/bip32@1.1.5':
+    dependencies:
+      '@noble/hashes': 1.2.0
+      '@noble/secp256k1': 1.7.1
+      '@scure/base': 1.1.9
+
   '@scure/bip32@1.4.0':
     dependencies:
       '@noble/curves': 1.4.2
@@ -8670,9 +9080,14 @@ snapshots:
 
   '@scure/bip32@1.7.0':
     dependencies:
-      '@noble/curves': 1.9.1
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
+
+  '@scure/bip39@1.1.1':
+    dependencies:
+      '@noble/hashes': 1.2.0
+      '@scure/base': 1.1.9
 
   '@scure/bip39@1.3.0':
     dependencies:
@@ -8684,7 +9099,56 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
+  '@sentry/core@5.30.0':
+    dependencies:
+      '@sentry/hub': 5.30.0
+      '@sentry/minimal': 5.30.0
+      '@sentry/types': 5.30.0
+      '@sentry/utils': 5.30.0
+      tslib: 1.14.1
+
   '@sentry/core@9.47.1': {}
+
+  '@sentry/hub@5.30.0':
+    dependencies:
+      '@sentry/types': 5.30.0
+      '@sentry/utils': 5.30.0
+      tslib: 1.14.1
+
+  '@sentry/minimal@5.30.0':
+    dependencies:
+      '@sentry/hub': 5.30.0
+      '@sentry/types': 5.30.0
+      tslib: 1.14.1
+
+  '@sentry/node@5.30.0':
+    dependencies:
+      '@sentry/core': 5.30.0
+      '@sentry/hub': 5.30.0
+      '@sentry/tracing': 5.30.0
+      '@sentry/types': 5.30.0
+      '@sentry/utils': 5.30.0
+      cookie: 0.4.2
+      https-proxy-agent: 5.0.1
+      lru_map: 0.3.3
+      tslib: 1.14.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sentry/tracing@5.30.0':
+    dependencies:
+      '@sentry/hub': 5.30.0
+      '@sentry/minimal': 5.30.0
+      '@sentry/types': 5.30.0
+      '@sentry/utils': 5.30.0
+      tslib: 1.14.1
+
+  '@sentry/types@5.30.0': {}
+
+  '@sentry/utils@5.30.0':
+    dependencies:
+      '@sentry/types': 5.30.0
+      tslib: 1.14.1
 
   '@sinclair/typebox@0.27.10': {}
 
@@ -8778,6 +9242,14 @@ snapshots:
       ts-essentials: 7.0.3(typescript@5.9.3)
       typechain: 8.3.2(typescript@5.9.3)
       typescript: 5.9.3
+
+  '@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.16.0)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3))(ethers@6.16.0)(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3))(typechain@8.3.2(typescript@5.9.3))':
+    dependencies:
+      '@typechain/ethers-v6': 0.5.1(ethers@6.16.0)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)
+      ethers: 6.16.0
+      fs-extra: 9.1.0
+      hardhat: 2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
+      typechain: 8.3.2(typescript@5.9.3)
 
   '@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.16.0)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3))(ethers@6.16.0)(hardhat@3.2.0)(typechain@8.3.2(typescript@5.9.3))':
     dependencies:
@@ -8973,7 +9445,7 @@ snapshots:
 
   '@types/minimatch@6.0.0':
     dependencies:
-      minimatch: 10.2.2
+      minimatch: 10.2.5
 
   '@types/mocha@10.0.10': {}
 
@@ -9453,6 +9925,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  aggregate-error@3.1.0:
+    dependencies:
+      clean-stack: 2.2.0
+      indent-string: 4.0.0
+
   ajv-formats@2.1.1(ajv@8.12.0):
     optionalDependencies:
       ajv: 8.12.0
@@ -9511,6 +9988,10 @@ snapshots:
 
   amdefine@1.0.1:
     optional: true
+
+  ansi-align@3.0.1:
+    dependencies:
+      string-width: 4.2.3
 
   ansi-colors@4.1.3: {}
 
@@ -9610,7 +10091,7 @@ snapshots:
 
   axios@1.16.1:
     dependencies:
-      follow-redirects: 1.16.0
+      follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.5
       https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
@@ -9778,6 +10259,17 @@ snapshots:
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  boxen@5.1.2:
+    dependencies:
+      ansi-align: 3.0.1
+      camelcase: 6.3.0
+      chalk: 4.1.2
+      cli-boxes: 2.2.1
+      string-width: 4.2.3
+      type-fest: 0.20.2
+      widest-line: 3.1.0
+      wrap-ansi: 7.0.0
 
   brace-expansion@1.1.12:
     dependencies:
@@ -9978,6 +10470,8 @@ snapshots:
 
   chrome-trace-event@1.0.4: {}
 
+  ci-info@2.0.0: {}
+
   ci-info@3.9.0: {}
 
   ci-info@4.4.0: {}
@@ -9999,6 +10493,10 @@ snapshots:
       '@types/validator': 13.15.10
       libphonenumber-js: 1.12.37
       validator: 13.15.26
+
+  clean-stack@2.2.0: {}
+
+  cli-boxes@2.2.1: {}
 
   cli-cursor@3.1.0:
     dependencies:
@@ -10058,6 +10556,8 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  command-exists@1.2.9: {}
+
   command-line-args@5.2.1:
     dependencies:
       array-back: 3.1.0
@@ -10079,6 +10579,8 @@ snapshots:
   commander@2.20.3: {}
 
   commander@4.1.1: {}
+
+  commander@8.3.0: {}
 
   comment-json@4.2.5:
     dependencies:
@@ -10124,6 +10626,8 @@ snapshots:
   cookie-signature@1.0.7: {}
 
   cookie-signature@1.2.2: {}
+
+  cookie@0.4.2: {}
 
   cookie@0.7.2: {}
 
@@ -10329,6 +10833,8 @@ snapshots:
   diff@4.0.4: {}
 
   diff@5.2.2: {}
+
+  diff@7.0.0: {}
 
   difflib@0.2.4:
     dependencies:
@@ -10659,6 +11165,13 @@ snapshots:
       secp256k1: 4.0.4
       setimmediate: 1.0.5
 
+  ethereum-cryptography@1.2.0:
+    dependencies:
+      '@noble/hashes': 1.2.0
+      '@noble/secp256k1': 1.7.1
+      '@scure/bip32': 1.1.5
+      '@scure/bip39': 1.1.1
+
   ethereum-cryptography@2.2.1:
     dependencies:
       '@noble/curves': 1.4.2
@@ -10944,7 +11457,9 @@ snapshots:
 
   follow-redirects@1.15.11: {}
 
-  follow-redirects@1.16.0: {}
+  follow-redirects@1.16.0(debug@4.4.3):
+    optionalDependencies:
+      debug: 4.4.3(supports-color@8.1.1)
 
   for-each@0.3.5:
     dependencies:
@@ -11004,6 +11519,8 @@ snapshots:
       once: 1.4.0
 
   forwarded@0.2.0: {}
+
+  fp-ts@1.19.3: {}
 
   fraction.js@5.3.4: {}
 
@@ -11238,6 +11755,32 @@ snapshots:
     optionalDependencies:
       uglify-js: 3.19.3
 
+  hardhat-gas-reporter@2.3.0(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3))(typescript@5.9.3)(zod@3.25.76):
+    dependencies:
+      '@ethersproject/abi': 5.8.0
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/units': 5.8.0
+      '@solidity-parser/parser': 0.20.2
+      axios: 1.16.1
+      brotli-wasm: 2.0.1
+      chalk: 4.1.2
+      cli-table3: 0.6.5
+      ethereum-cryptography: 2.2.1
+      glob: 10.5.0
+      hardhat: 2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
+      jsonschema: 1.5.0
+      lodash: 4.17.23
+      markdown-table: 2.0.0
+      sha1: 1.1.1
+      viem: 2.47.6(typescript@5.9.3)(zod@3.25.76)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - zod
+
   hardhat-gas-reporter@2.3.0(hardhat@3.2.0)(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@ethersproject/abi': 5.8.0
@@ -11263,6 +11806,55 @@ snapshots:
       - typescript
       - utf-8-validate
       - zod
+
+  hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3):
+    dependencies:
+      '@ethereumjs/util': 9.1.0
+      '@ethersproject/abi': 5.8.0
+      '@nomicfoundation/edr': 0.12.0-next.23
+      '@nomicfoundation/solidity-analyzer': 0.1.2
+      '@sentry/node': 5.30.0
+      adm-zip: 0.4.16
+      aggregate-error: 3.1.0
+      ansi-escapes: 4.3.2
+      boxen: 5.1.2
+      chokidar: 4.0.3
+      ci-info: 2.0.0
+      debug: 4.4.3(supports-color@8.1.1)
+      enquirer: 2.4.1
+      env-paths: 2.2.1
+      ethereum-cryptography: 1.2.0
+      find-up: 5.0.0
+      fp-ts: 1.19.3
+      fs-extra: 7.0.1
+      immutable: 4.3.9
+      io-ts: 1.10.4
+      json-stream-stringify: 3.1.6
+      keccak: 3.0.4
+      lodash: 4.17.23
+      micro-eth-signer: 0.14.0
+      mnemonist: 0.38.5
+      mocha: 11.7.6
+      p-map: 4.0.0
+      picocolors: 1.1.1
+      raw-body: 2.5.3
+      resolve: 1.17.0
+      semver: 6.3.1
+      solc: 0.8.26(debug@4.4.3)
+      source-map-support: 0.5.21
+      stacktrace-parser: 0.1.11
+      tinyglobby: 0.2.17
+      tsort: 0.0.1
+      undici: 5.29.0
+      uuid: 8.3.2
+      ws: 7.5.13
+    optionalDependencies:
+      ts-node: 10.9.2(@types/node@20.19.33)(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   hardhat@3.2.0:
     dependencies:
@@ -11384,6 +11976,8 @@ snapshots:
 
   immer@11.1.8: {}
 
+  immutable@4.3.9: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -11395,6 +11989,8 @@ snapshots:
       resolve-cwd: 3.0.0
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inflight@1.0.6:
     dependencies:
@@ -11444,6 +12040,10 @@ snapshots:
   internmap@2.0.3: {}
 
   interpret@1.4.0: {}
+
+  io-ts@1.10.4:
+    dependencies:
+      fp-ts: 1.19.3
 
   ioredis@5.11.0:
     dependencies:
@@ -12220,7 +12820,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   jest-validate@29.7.0:
     dependencies:
@@ -12573,6 +13173,8 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lru_map@0.3.3: {}
+
   lucide-react@1.17.0(react@19.2.6):
     dependencies:
       react: 19.2.6
@@ -12622,6 +13224,8 @@ snapshots:
   memfs@3.5.3:
     dependencies:
       fs-monkey: 1.1.0
+
+  memorystream@0.3.1: {}
 
   merge-descriptors@1.0.3: {}
 
@@ -12717,6 +13321,10 @@ snapshots:
 
   mkdirp@1.0.4: {}
 
+  mnemonist@0.38.5:
+    dependencies:
+      obliterator: 2.0.5
+
   mocha@10.8.2:
     dependencies:
       ansi-colors: 4.1.3
@@ -12738,6 +13346,30 @@ snapshots:
       workerpool: 6.5.1
       yargs: 16.2.0
       yargs-parser: 20.2.9
+      yargs-unparser: 2.0.0
+
+  mocha@11.7.6:
+    dependencies:
+      browser-stdout: 1.3.1
+      chokidar: 4.0.3
+      debug: 4.4.3(supports-color@8.1.1)
+      diff: 7.0.0
+      escape-string-regexp: 4.0.0
+      find-up: 5.0.0
+      glob: 10.5.0
+      he: 1.2.0
+      is-path-inside: 3.0.3
+      js-yaml: 4.1.1
+      log-symbols: 4.1.0
+      minimatch: 9.0.5
+      ms: 2.1.3
+      picocolors: 1.1.1
+      serialize-javascript: 6.0.2
+      strip-json-comments: 3.1.1
+      supports-color: 8.1.1
+      workerpool: 9.3.4
+      yargs: 17.7.2
+      yargs-parser: 21.1.1
       yargs-unparser: 2.0.0
 
   motion-dom@12.40.0:
@@ -12863,6 +13495,8 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
+  obliterator@2.0.5: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -12939,6 +13573,10 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-map@4.0.0:
+    dependencies:
+      aggregate-error: 3.1.0
 
   p-map@7.0.4: {}
 
@@ -13053,8 +13691,6 @@ snapshots:
   picomatch@4.0.1: {}
 
   picomatch@4.0.2: {}
-
-  picomatch@4.0.3: {}
 
   picomatch@4.0.4: {}
 
@@ -13270,6 +13906,10 @@ snapshots:
 
   resolve@1.1.7: {}
 
+  resolve@1.17.0:
+    dependencies:
+      path-parse: 1.0.7
+
   resolve@1.22.11:
     dependencies:
       is-core-module: 2.16.1
@@ -13390,6 +14030,8 @@ snapshots:
       elliptic: 6.6.1
       node-addon-api: 5.1.0
       node-gyp-build: 4.8.4
+
+  semver@5.7.2: {}
 
   semver@6.3.1: {}
 
@@ -13531,6 +14173,41 @@ snapshots:
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
 
+  solc@0.8.26(debug@4.4.3):
+    dependencies:
+      command-exists: 1.2.9
+      commander: 8.3.0
+      follow-redirects: 1.16.0(debug@4.4.3)
+      js-sha3: 0.8.0
+      memorystream: 0.3.1
+      semver: 5.7.2
+      tmp: 0.0.33
+    transitivePeerDependencies:
+      - debug
+
+  solidity-coverage@0.8.17(hardhat@2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)):
+    dependencies:
+      '@ethersproject/abi': 5.8.0
+      '@solidity-parser/parser': 0.20.2
+      chalk: 2.4.2
+      death: 1.1.0
+      difflib: 0.2.4
+      fs-extra: 8.1.0
+      ghost-testrpc: 0.0.2
+      global-modules: 2.0.0
+      globby: 10.0.2
+      hardhat: 2.29.0(ts-node@10.9.2(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
+      jsonschema: 1.5.0
+      lodash: 4.17.23
+      mocha: 10.8.2
+      node-emoji: 1.11.0
+      pify: 4.0.1
+      recursive-readdir: 2.2.3
+      sc-istanbul: 0.4.6
+      semver: 7.7.4
+      shelljs: 0.8.5
+      web3-utils: 1.10.4
+
   solidity-coverage@0.8.17(hardhat@3.2.0):
     dependencies:
       '@ethersproject/abi': 5.8.0
@@ -13588,6 +14265,10 @@ snapshots:
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
+
+  stacktrace-parser@0.1.11:
+    dependencies:
+      type-fest: 0.7.1
 
   standard-as-callback@2.1.0: {}
 
@@ -13936,9 +14617,13 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
+  tslib@1.14.1: {}
+
   tslib@2.7.0: {}
 
   tslib@2.8.1: {}
+
+  tsort@0.0.1: {}
 
   tsx@4.21.0:
     dependencies:
@@ -13962,6 +14647,8 @@ snapshots:
   type-fest@0.20.2: {}
 
   type-fest@0.21.3: {}
+
+  type-fest@0.7.1: {}
 
   type-fest@4.41.0: {}
 
@@ -14130,6 +14817,8 @@ snapshots:
   uuid@11.0.3: {}
 
   uuid@11.1.0: {}
+
+  uuid@8.3.2: {}
 
   v8-compile-cache-lib@3.0.1: {}
 
@@ -14311,6 +15000,10 @@ snapshots:
     dependencies:
       string-width: 4.2.3
 
+  widest-line@3.1.0:
+    dependencies:
+      string-width: 4.2.3
+
   word-wrap@1.2.5: {}
 
   wordwrap@1.0.0: {}
@@ -14321,6 +15014,8 @@ snapshots:
       typical: 5.2.0
 
   workerpool@6.5.1: {}
+
+  workerpool@9.3.4: {}
 
   wrap-ansi@6.2.0:
     dependencies:
@@ -14351,6 +15046,8 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
+
+  ws@7.5.13: {}
 
   ws@8.17.1: {}
 

--- a/test/calldata/CalldataUnpacker.test.ts
+++ b/test/calldata/CalldataUnpacker.test.ts
@@ -1,0 +1,115 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import type { Contract } from "ethers";
+
+interface PackedEntry {
+  recipient: string;
+  amount: bigint;
+}
+
+function packEntries(entries: PackedEntry[]): string {
+  return ethers.concat(
+    entries.map((entry) =>
+      ethers.solidityPacked(["address", "uint96"], [entry.recipient, entry.amount])
+    )
+  );
+}
+
+function abiEncodeEntries(entries: PackedEntry[]): string {
+  const coder = ethers.AbiCoder.defaultAbiCoder();
+  return coder.encode(
+    ["tuple(address recipient, uint96 amount)[]"],
+    [entries.map((e) => [e.recipient, e.amount])]
+  );
+}
+
+describe("CalldataUnpacker", function () {
+  let unpacker: Contract;
+  let entries: PackedEntry[];
+
+  beforeEach(async function () {
+    const Unpacker = await ethers.getContractFactory("CalldataUnpacker");
+    unpacker = await Unpacker.deploy();
+    await unpacker.waitForDeployment();
+
+    const signers = await ethers.getSigners();
+    entries = signers.slice(0, 3).map((signer, i) => ({
+      recipient: signer.address,
+      amount: BigInt(1000 * (i + 1)),
+    }));
+  });
+
+  describe("decodeEntryAt", function () {
+    it("decodes a single packed entry's address and amount", async function () {
+      const payload = packEntries(entries);
+      const [recipient, amount] = await unpacker.decodeEntryAt(payload, 1);
+
+      expect(recipient).to.equal(entries[1].recipient);
+      expect(amount).to.equal(entries[1].amount);
+    });
+  });
+
+  describe("unpackBatch", function () {
+    it("credits totalReceived and emits an event for every packed entry", async function () {
+      const payload = packEntries(entries);
+
+      await expect(unpacker.unpackBatch(payload))
+        .to.emit(unpacker, "Unpacked")
+        .withArgs(entries[0].recipient, entries[0].amount);
+
+      for (const entry of entries) {
+        expect(await unpacker.totalReceived(entry.recipient)).to.equal(entry.amount);
+      }
+    });
+
+    it("returns the number of entries processed", async function () {
+      const payload = packEntries(entries);
+      const processed = await unpacker.unpackBatch.staticCall(payload);
+      expect(processed).to.equal(entries.length);
+    });
+
+    it("reverts when the payload length is not a multiple of 32 bytes", async function () {
+      const malformed = ethers.concat([packEntries(entries), "0x00"]);
+      await expect(unpacker.unpackBatch(malformed)).to.be.revertedWithCustomError(
+        unpacker,
+        "InvalidPayloadLength"
+      );
+    });
+
+    it("reverts on an empty payload", async function () {
+      await expect(unpacker.unpackBatch("0x")).to.be.revertedWithCustomError(
+        unpacker,
+        "InvalidPayloadLength"
+      );
+    });
+  });
+
+  describe("gas comparison vs. abi.decode baseline", function () {
+    it("unpackBatch uses meaningfully less gas than the abi.decode baseline", async function () {
+      const packedPayload = packEntries(entries);
+      const abiPayload = abiEncodeEntries(entries);
+
+      const packedReceipt = await (await unpacker.unpackBatch(packedPayload)).wait();
+
+      // Fresh contract so totals/state don't carry over between the two paths.
+      const Unpacker = await ethers.getContractFactory("CalldataUnpacker");
+      const baselineUnpacker = await Unpacker.deploy();
+      await baselineUnpacker.waitForDeployment();
+      const abiReceipt = await (
+        await baselineUnpacker.multicallAbiDecodeBaseline(abiPayload)
+      ).wait();
+
+      const packedGas = Number(packedReceipt.gasUsed);
+      const abiGas = Number(abiReceipt.gasUsed);
+      const savingsPerItem = (abiGas - packedGas) / entries.length;
+
+      console.log(`      packed calldata bytes: ${(packedPayload.length - 2) / 2}`);
+      console.log(`      abi.decode calldata bytes: ${(abiPayload.length - 2) / 2}`);
+      console.log(`      unpackBatch gas: ${packedGas}`);
+      console.log(`      abi.decode baseline gas: ${abiGas}`);
+      console.log(`      gas saved per item: ${savingsPerItem}`);
+
+      expect(packedGas).to.be.lessThan(abiGas);
+    });
+  });
+});

--- a/test/storage/YulArrayUtils.test.ts
+++ b/test/storage/YulArrayUtils.test.ts
@@ -1,0 +1,106 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import type { Contract } from "ethers";
+
+describe("YulArrayUtils", function () {
+  let harness: Contract;
+
+  beforeEach(async function () {
+    const Harness = await ethers.getContractFactory("YulArrayUtilsHarness");
+    harness = await Harness.deploy();
+    await harness.waitForDeployment();
+  });
+
+  describe("uint256[] removal", function () {
+    beforeEach(async function () {
+      for (const value of [10, 20, 30, 40]) {
+        await harness.pushNumber(value);
+      }
+    });
+
+    it("swaps the last element into the removed index and shrinks the array", async function () {
+      await harness.removeNumberAt(1); // remove 20
+
+      const numbers = await harness.getNumbers();
+      expect(numbers.map((n: bigint) => Number(n))).to.deep.equal([10, 40, 30]);
+      expect(await harness.numbersLength()).to.equal(3);
+    });
+
+    it("removing the last element is a plain pop with no swap needed", async function () {
+      await harness.removeNumberAt(3); // remove 40 (tail)
+
+      const numbers = await harness.getNumbers();
+      expect(numbers.map((n: bigint) => Number(n))).to.deep.equal([10, 20, 30]);
+    });
+
+    it("removes down to an empty array", async function () {
+      await harness.removeNumberAt(0);
+      await harness.removeNumberAt(0);
+      await harness.removeNumberAt(0);
+      await harness.removeNumberAt(0);
+
+      expect(await harness.numbersLength()).to.equal(0);
+    });
+
+    it("reverts on an out-of-bounds index", async function () {
+      await expect(harness.removeNumberAt(99)).to.be.revertedWithCustomError(
+        harness,
+        "IndexOutOfBounds"
+      );
+    });
+  });
+
+  describe("address[] removal", function () {
+    it("swaps and pops addresses the same way", async function () {
+      const signers = await ethers.getSigners();
+      const addrs = signers.slice(0, 3).map((s) => s.address);
+
+      for (const addr of addrs) {
+        await harness.pushAddress(addr);
+      }
+
+      await harness.removeAddressAt(0);
+
+      const remaining = await harness.getAddresses();
+      expect(remaining).to.deep.equal([addrs[2], addrs[1]]);
+      expect(await harness.addressesLength()).to.equal(2);
+    });
+  });
+
+  describe("O(1) cost characteristic", function () {
+    it("removal gas cost does not scale with array length", async function () {
+      // Use two independent, freshly-deployed harnesses (so every slot
+      // starts pristine/zero in both cases) and non-zero values throughout
+      // (a stored `0` is a special, cheaper SSTORE case that would bias the
+      // comparison). Removing index 0 from a 20-element array should then
+      // cost essentially the same as removing index 0 from a 200-element
+      // array — unlike Solidity's shifting-based removal, whose cost grows
+      // with the number of elements shifted.
+      const Harness = await ethers.getContractFactory("YulArrayUtilsHarness");
+
+      const smallHarness = await Harness.deploy();
+      await smallHarness.waitForDeployment();
+      for (let i = 0; i < 20; i++) {
+        await smallHarness.pushNumber(i + 1);
+      }
+      const txSmall = await (await smallHarness.removeNumberAt(0)).wait();
+
+      const largeHarness = await Harness.deploy();
+      await largeHarness.waitForDeployment();
+      for (let i = 0; i < 200; i++) {
+        await largeHarness.pushNumber(i + 1);
+      }
+      const txLarge = await (await largeHarness.removeNumberAt(0)).wait();
+
+      const gasSmall = Number(txSmall.gasUsed);
+      const gasLarge = Number(txLarge.gasUsed);
+
+      // Allow a small tolerance (e.g. keccak256 base cost is identical, but
+      // intrinsic calldata cost can differ by a few gas) — the point is the
+      // delta is nowhere near linear in the number of elements shifted
+      // (which would add ~180 extra cold SSTOREs for the shift-based
+      // approach, i.e. tens of thousands of gas).
+      expect(Math.abs(gasLarge - gasSmall)).to.be.lessThan(500);
+    });
+  });
+});


### PR DESCRIPTION
## #644 — Generic Yul Assembly Storage Array Removal Helper

Adds `contracts/storage/YulArrayUtils.sol`, a library that performs O(1) swap-and-pop removal from `uint256[]`/`address[]` storage arrays directly in Yul: it locates the array's element base slot via `keccak256(arr.slot)`, moves the last element into the target index with `sload`/`sstore`, zeroes the vacated final slot (to claim the storage refund), and decrements the length slot — all in a single assembly block instead of Solidity's element-by-element shifting. `YulArrayUtilsHarness` exposes it for testing.

## #643 — Memory Allocation Profiler to Guard Against Quadratic Expansion

- `gasguard-cli/src/analyzers/memory_profiler.rs` (`packages/cli/src/analyzers/memory_profiler.rs`, crate name `gasguard-cli`): a `MemoryProfiler` that tracks free-memory-pointer growth across recorded allocation steps, computes the EVM's `C_mem(a) = 3a + a²/512` expansion cost formula, and flags any function whose cumulative allocations exceed the 1024-byte critical threshold. Follows the sibling `ScanAnalyzer`/`SorobanAnalyzer` struct-of-`pub fn` pattern used elsewhere in the workspace's Rust analyzers rather than introducing a new trait.
- `contracts/profiler/MemoryCheck.sol`: on-chain companion that reads the live free memory pointer (`mload(0x40)`), computes the same expansion-cost formula, and emits measured allocation deltas — giving runtime ground truth to check the static analyzer's predictions against.

## #642 — Gas-Optimized Custom Calldata Unpacker for Multi-Calls

`contracts/calldata/CalldataUnpacker.sol` decodes tightly packed multicall payloads (32 bytes/entry: 20-byte address + 12-byte `uint96`, no ABI padding) directly off `calldata` using `calldataload` + bit shifts, avoiding `abi.decode`'s memory allocation and copy overhead. Includes `multicallAbiDecodeBaseline`, a standard `abi.decode`-based twin used purely to benchmark against.

Measured in `test/calldata/CalldataUnpacker.test.ts` for a 3-entry batch:
- calldata size: 96 bytes packed vs. 256 bytes ABI-encoded
- gas: 94,682 (`unpackBatch`) vs. 97,488 (`abi.decode` baseline) — **~935 gas saved per item**

## #641 — Minimize Logic Contract Deployment Size via Internal Function Delegate

No pre-existing oversized implementation contract existed in the repo, so this adds a realistic example fitting the codebase's existing gas-subsidy/tiered-pricing domain (see `apps/api-service/src/gas-subsidy`, `README_TIERED_PRICING.md`):

- `contracts/libraries/DelegateLogicLib.sol`: tier resolution, discount math, batch fee aggregation, rolling rate-limit checks, and EIP-191 signature recovery — all as `public` library functions, so the compiler deploys them as a separate library contract linked via a thin call stub (unlike `internal` functions, which the compiler inlines into every caller and provide no size benefit).
- `contracts/proxy/CompactImplementation.sol`: the upgradeable logic contract, which only orchestrates state and delegates every non-trivial computation to `DelegateLogicLib`.

`forge build --sizes`:
| Contract | Runtime size | Margin under 24,576-byte EIP-170 limit |
|---|---|---|
| `CompactImplementation` | 2,297 bytes | 22,279 bytes (~91%) |
| `DelegateLogicLib` (separate deployment) | 1,843 bytes | 22,733 bytes |

## Test plan

- [x] `forge build --sizes` — all 6 new contracts compile; `CompactImplementation` is 2,297 bytes, well under the 24,576-byte EIP-170 limit
- [x] `npx hardhat test` — 12/12 passing (`YulArrayUtils`, `CalldataUnpacker`, including the gas-comparison test against the `abi.decode` baseline)
- [x] `cargo test -p gasguard-cli` — 6/6 passing (`memory_profiler` unit tests, including known EVM memory-expansion-cost checkpoints)

### Out of scope
- Added a root `hardhat.config.ts` + `foundry.toml` (pointing at the new `contracts/`/`test/` directories) since no Solidity build tooling existed at the repo root before this PR; `apps/api-service`'s own Hardhat 3 setup and `tests/gas/GasBenchmarkSuite.t.sol` (which needs an un-vendored `forge-std`) are untouched.
- Pre-existing `.husky/pre-commit` hook isn't executable and the repo's Git LFS hook assumes `git-lfs` is installed locally — unrelated to this change, left as-is.

Closes #641
Closes #642
Closes #643
Closes #644