### PR TITLE
Inline common access control checks into unchecked helpers

### DIFF
--- a/contracts/access/GasGuardAccess.sol
+++ b/contracts/access/GasGuardAccess.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+abstract contract GasGuardAccess {
+    address public owner;
+    address public pendingOwner;
+
+    error Unauthorized();
+    error ZeroAddress();
+    error AlreadySet();
+
+    event OwnershipTransferStarted(address indexed from, address indexed to);
+
+    constructor(address owner_) {
+        if (owner_ == address(0)) revert ZeroAddress();
+        owner = owner_;
+    }
+
+    function _checkOwner() internal view {
+        if (msg.sender != owner) revert Unauthorized();
+    }
+
+    modifier onlyOwner() {
+        _checkOwner();
+        _;
+    }
+
+    function transferOwnership(address newOwner) external onlyOwner {
+        if (newOwner == address(0)) revert ZeroAddress();
+        pendingOwner = newOwner;
+        emit OwnershipTransferStarted(owner, newOwner);
+    }
+
+    function acceptOwnership() external {
+        if (msg.sender != pendingOwner) revert Unauthorized();
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}


### PR DESCRIPTION
## Summary

Refactored access control modifiers to invoke a non-inlined internal view function instead of repeating identical check bytecode at every function entry point, reducing deployment bytecode for multi-guarded contracts.

### Changes

- Created `contracts/access/GasGuardAccess.sol` with internal `_checkOwner()` helper
- Modifier `onlyOwner` delegates to `_checkOwner()` instead of inlining the check
- Added standard two-step ownership transfer pattern

Closes #739
Closes #738
Closes #737
Closes #736