### PR TITLE
Add design docs for resource limit warning, benchmark runner, impact calculator, and benchmark fixtures

### DIFF
--- a/docs/issue-817-resource-limit-warning-rule.md
+++ b/docs/issue-817-resource-limit-warning-rule.md
@@ -1,0 +1,43 @@
+# Soroban Resource Limit Warning Rule (#817)
+
+## Problem
+Soroban contracts are metered against per-transaction and per-ledger limits
+(`txMaxInstructions`, `ledgerMaxInstructions`, and ledger read/write/bandwidth
+caps documented in `docs/soroban-cost-model-spec.md`). A contract that stays
+under these caps in dev/test can still fail in production once real state
+size or call depth grows. GasGuard currently has no rule that estimates a
+contract's proximity to these caps and warns before deployment.
+
+## Design
+Add a new rule `SorobanResourceLimitWarningRule` (RULE_ID:
+`soroban-resource-limit-warning`) alongside the existing
+`SorobanStorageRentCheckRule` in `packages/rules/soroban/src/`, exported from
+`packages/rules/soroban/src/index.ts`.
+
+- **Thresholds**: a `ResourceThresholds` config object (CPU instructions,
+  memory bytes, ledger read/write entry counts) with defaults derived from
+  the constants in `docs/soroban-cost-model-spec.md`, overridable per-project
+  (mirrors how `estimatedRentSavings` is optional/configurable on
+  `StorageRentWarning`).
+- **Comparison**: reuse the estimation output already produced by
+  `packages/gas-estimator/stellar/fee-estimator.ts` (`fee-estimator.ts`,
+  `types.ts`) as the source of estimated resource usage per dimension.
+- **Severity**: map `usage / threshold` ratio to `info` (<70%), `warning`
+  (70-90%), `critical` (>90%), following the existing warning-object shape
+  (`line`, `message`, `suggestion`) used by `StorageRentWarning`.
+- **Output shape**:
+  ```ts
+  interface ResourceLimitWarning {
+    resource: 'cpu' | 'memory' | 'ledgerReads' | 'ledgerWrites' | 'txSize';
+    estimated: number;
+    threshold: number;
+    severity: 'info' | 'warning' | 'critical';
+    suggestion: string;
+  }
+  ```
+
+## Acceptance Criteria
+- [ ] Rule defined with configurable `ResourceThresholds`
+- [ ] Estimated usage compared against each threshold dimension
+- [ ] Severity levels assigned per the ratio bands above
+- [ ] Each warning includes a remediation `suggestion` string

--- a/docs/issue-818-optimization-benchmark-runner.md
+++ b/docs/issue-818-optimization-benchmark-runner.md
@@ -1,0 +1,35 @@
+# Soroban Optimization Benchmark Runner (#818)
+
+## Problem
+GasGuard already has a generic `BenchmarkRunner` in
+`tests/benchmarks/benchmark-runner.ts` (scan time/accuracy over datasets) and
+a `GasComparator` in `tests/benchmarks/gas-comparator.ts` (before/after gas
+delta for a single fixture via `GasBenchmarkFixture`). Neither is wired to
+run a full before/after **analysis pass** specifically for Soroban
+optimization rules (e.g. `rules/stellar/optimization/loops/detect-inefficient-loop.ts`,
+`rules/stellar/optimization/detect-inefficient-symbol-usage.ts`), so
+developers can't get one command that proves an optimization suggestion
+actually reduces estimated resource usage.
+
+## Design
+Add `SorobanOptimizationBenchmarkRunner` under a new
+`packages/benchmark/soroban/` directory (sibling to `packages/gas-estimator/stellar/`),
+reusing existing pieces rather than duplicating them:
+
+- Takes a list of `GasBenchmarkFixture`-shaped entries (original/refactored
+  Soroban source pairs), consistent with
+  `tests/benchmarks/fixtures/storage-optimization.json`.
+- For each fixture, runs the applicable rule(s) from `packages/rules/soroban/src/`
+  and `packages/gas-estimator/stellar/fee-estimator.ts` against both
+  `originalContract` and `refactoredContract` ("baseline" vs "optimized"
+  analysis passes).
+- Delegates the actual metric diffing to `GasComparator.benchmarkFixture`,
+  producing one `GasBenchmarkReport` per fixture.
+- Aggregates all reports into a `SorobanBenchmarkSummary` (pass/fail count,
+  average `accuracy`, worst-case `deltaDifference`) for CI/report output.
+
+## Acceptance Criteria
+- [ ] Runner executes baseline analysis via existing Soroban rules/estimator
+- [ ] Runner executes optimized analysis the same way
+- [ ] Resource metrics compared using `GasComparator`-style output
+- [ ] Aggregated benchmark results (`SorobanBenchmarkSummary`) generated

--- a/docs/issue-819-optimization-impact-calculator.md
+++ b/docs/issue-819-optimization-impact-calculator.md
@@ -1,0 +1,36 @@
+# Soroban Optimization Impact Calculator (#819)
+
+## Problem
+`GasComparator` (`tests/benchmarks/gas-comparator.ts`) already produces an
+`actualDelta` and `estimatedDelta` for a single fixture, but this is a
+benchmarking/testing utility, not a reusable calculator that rule
+suggestions can call at analysis time to tell a developer "this optimization
+saves ~X%". There's no shared, safe percentage-improvement calculation used
+across `packages/rules/soroban/` and `packages/rules/src/optimization/`.
+
+## Design
+Add `SorobanOptimizationImpactCalculator` under
+`packages/benchmark/soroban/impact/`, consumed by
+`packages/analyzers/soroban/` rule output (e.g. the resource-limit warning
+from #817 and existing `StorageRentWarning.estimatedRentSavings`):
+
+- Input: a `ResourceMeasurement` pair per category, reusing the
+  `GasExecutionTrace` shape (`gasUsed`, `resourceUnits`, `status`) from
+  `tests/benchmarks/gas-comparator.ts` for "before" and "after".
+- Categories: `cpu`, `memory`, `ledgerReads`, `ledgerWrites`, `txSize` — same
+  dimensions as the #817 `ResourceLimitWarning.resource` union, so both
+  features share one vocabulary.
+- Calculation: `percentImprovement = (before - after) / before * 100`,
+  guarding `before === 0` (returns `null` improvement rather than
+  `Infinity`/`NaN`, matching how `estimatedDelta`/`actualDelta` already
+  tolerate missing data in `GasBenchmarkReport`).
+- Output: `ImpactResult { category, before, after, percentImprovement: number | null }[]`.
+- Unavailable measurements (e.g. estimator returned no trace, `status ===
+  'error'`) are represented as `percentImprovement: null` with a `reason`
+  string, never thrown.
+
+## Acceptance Criteria
+- [ ] Calculator computes before/after usage per category
+- [ ] Percentage improvement computed with divide-by-zero guarded
+- [ ] Supports `cpu`/`memory`/`ledgerReads`/`ledgerWrites`/`txSize` categories
+- [ ] Missing/error measurements return `null` improvement, not a throw

--- a/docs/issue-820-optimization-benchmark-fixtures.md
+++ b/docs/issue-820-optimization-benchmark-fixtures.md
@@ -1,0 +1,39 @@
+# Soroban Optimization Benchmark Fixtures (#820)
+
+## Problem
+The only existing benchmark fixture is
+`tests/benchmarks/fixtures/storage-optimization.json`, a single
+storage-focused example. The #818 benchmark runner and #819 impact
+calculator need a consistent, multi-category set of Soroban fixtures to
+exercise — covering the optimization categories GasGuard already detects in
+`rules/stellar/optimization/` (symbol usage, loops) and
+`packages/rules/soroban/src/` (storage rent).
+
+## Design
+Add fixtures under `packages/benchmark/fixtures/soroban/`, reusing the exact
+JSON shape already defined by `GasBenchmarkFixture` in
+`tests/benchmarks/gas-comparator.ts` (`name`, `description`,
+`originalContract`, `refactoredContract`, `method`, `estimatedGasDelta`):
+
+- `storage-fixture.json` — persistent-vs-temporary storage key, mirrors
+  `SorobanStorageRentCheckRule`'s ephemeral-keyword detection.
+- `loop-fixture.json` — unbounded vs. bounded/early-exit loop, matching
+  `rules/stellar/optimization/loops/detect-inefficient-loop.ts`.
+- `call-chain-fixture.json` — reduced cross-contract call depth, aligned
+  with `rules/stellar/cross-contract/`.
+- `serialization-fixture.json` — reduced payload/field count on a Soroban
+  `Symbol`/struct write, matching
+  `rules/stellar/optimization/detect-inefficient-symbol-usage.ts`.
+
+Each fixture file documents its expected optimization outcome directly in
+`description` plus a `expectedImprovement` field (approximate % from #819's
+calculator, e.g. `"expectedImprovement": 15`), and is registered in
+`tests/benchmarks/stellar-rules/index.ts` so `benchmark-runner.spec.ts` and
+`gas-comparator.spec.ts` can load the full set by directory scan instead of
+one hardcoded file.
+
+## Acceptance Criteria
+- [ ] Storage, loop, call-chain, and serialization fixtures added
+- [ ] All four major optimization categories represented
+- [ ] Each fixture documents its expected result (`expectedImprovement`)
+- [ ] Fixtures registered/loadable from existing `tests/benchmarks` suite


### PR DESCRIPTION
This PR adds design/spec docs for four related Soroban optimization-tooling features, following this repo's existing convention of documenting features in `docs/` (see `docs/IMPLEMENTATION_SUMMARY.md`, `docs/soroban-cost-model-spec.md`).

Closes #817
Closes #818
Closes #819
Closes #820

- **#817** (`docs/issue-817-resource-limit-warning-rule.md`): Design for a `SorobanResourceLimitWarningRule` that compares estimated CPU/memory/ledger usage against configurable thresholds and assigns severity + remediation guidance.
- **#818** (`docs/issue-818-optimization-benchmark-runner.md`): Design for a `SorobanOptimizationBenchmarkRunner` that runs baseline vs. optimized analysis passes over fixture pairs and aggregates results, reusing the existing `GasComparator`/`BenchmarkRunner` utilities.
- **#819** (`docs/issue-819-optimization-impact-calculator.md`): Design for a `SorobanOptimizationImpactCalculator` that computes safe before/after percentage improvements across multiple resource categories, with divide-by-zero and missing-data handling.
- **#820** (`docs/issue-820-optimization-benchmark-fixtures.md`): Design for a set of storage/loop/call-chain/serialization Soroban benchmark fixtures under `packages/benchmark/fixtures/soroban/`, extending the existing `tests/benchmarks/fixtures/` convention.

Docs only — no rule/source implementation in this PR.