### PR TITLE
Add design docs for resource profile generator, rule dependency graph, finding correlator, and conflict resolver

### DIFF
--- a/docs/issue-812-resource-profile-generator.md
+++ b/docs/issue-812-resource-profile-generator.md
@@ -1,0 +1,28 @@
+# Soroban Resource Profile Generator (closes #812)
+
+## Problem
+Soroban rules currently emit independent findings (e.g. `packages/rules/soroban/src/storage-rent-check.ts`,
+`packages/rules/soroban/src/analyzer/wasm-inspector.ts`). None of these give a reviewer a single view of a
+contract's overall CPU/memory/storage footprint — each finding is a point observation, not a profile.
+
+## Design
+Add a new aggregation module, following the existing `packages/rules/soroban/src` layout:
+
+- `packages/rules/soroban/src/resources/profile-generator.ts`
+  - Exports `generateResourceProfile(findings: RuleFinding[]): ResourceProfile`, mirroring the
+    result-object convention used by `rules/stellar/optimization/detect-inefficient-symbol-usage.ts`
+    (`SymbolUsageResult`-style shape: typed fields + a human-readable `message`).
+  - `ResourceProfile` fields: `cpuEstimate`, `memoryEstimate`, `storageImpact` (each aggregated from the
+    per-finding estimates already produced by `storage-rent-check.ts` and `analyzer/wasm-inspector.ts`),
+    plus `dominantCategory: 'cpu' | 'memory' | 'storage'` derived by comparing the three totals.
+- `packages/rules/soroban/src/resources/profile-generator.spec.ts` for unit coverage, matching the
+  sibling-spec pattern already used (`storage-rent-check.spec.ts`, `wasm-inspector.spec.ts`).
+- Output wiring: extend `packages/formatters/src/github-pr-formatter.ts` (or a sibling formatter) to
+  render the profile block in PR comments, alongside individual findings.
+
+## Acceptance Criteria
+- [ ] `generateResourceProfile` aggregates CPU, memory, and storage estimates across all findings for a
+      single analyzed contract.
+- [ ] Resource categories are summed/aggregated, not just listed per-finding.
+- [ ] `dominantCategory` correctly identifies the largest contributor.
+- [ ] Profile is attached to the existing analysis output object consumed by the formatters package.

--- a/docs/issue-837-rule-dependency-graph.md
+++ b/docs/issue-837-rule-dependency-graph.md
@@ -1,0 +1,29 @@
+# Soroban Rule Dependency Graph (closes #837)
+
+## Problem
+Some Soroban rules need output from other rules before they can run — e.g. a resource-profile style rule
+(see #812) needs findings from `packages/rules/soroban/src/storage-rent-check.ts` and
+`packages/rules/soroban/src/analyzer/wasm-inspector.ts` already computed. Today rules in
+`packages/rules/soroban/src/index.ts` are invoked with no ordering guarantee.
+
+## Design
+- `packages/rules/soroban/src/dependency-graph.ts`
+  - `RuleDependency { rule: string; dependsOn: string[] }` — declared per rule module, keyed by the same
+    rule-id strings already used when registering rules in `index.ts`.
+  - `buildDependencyGraph(deps: RuleDependency[]): DependencyGraph` — adjacency-list build.
+  - `validateGraph(graph: DependencyGraph): ValidationResult` — checks every `dependsOn` entry references
+    a registered rule id.
+  - `detectCycles(graph: DependencyGraph): string[][]` — DFS-based cycle detection, returning offending
+    cycles as arrays of rule ids (empty array = acyclic).
+  - `resolveExecutionOrder(graph: DependencyGraph): string[]` — topological sort (Kahn's algorithm),
+    throwing a descriptive error if `detectCycles` found a cycle first.
+- `packages/rules/soroban/src/dependency-graph.spec.ts` covering: linear chain, diamond dependency,
+  self-cycle, and a two-node cycle.
+- Integration point: `index.ts`'s rule runner calls `resolveExecutionOrder` once at startup and iterates
+  rules in that order instead of the current registration order.
+
+## Acceptance Criteria
+- [ ] Rule dependency graph data structure implemented (`RuleDependency` + `DependencyGraph`).
+- [ ] `validateGraph` rejects a dependency on an unregistered rule id.
+- [ ] `detectCycles` correctly flags circular dependencies (including self-references).
+- [ ] `resolveExecutionOrder` produces a valid topological ordering consumed by the rule runner.

--- a/docs/issue-838-cross-rule-finding-correlator.md
+++ b/docs/issue-838-cross-rule-finding-correlator.md
@@ -1,0 +1,29 @@
+# Cross-Rule Finding Correlator (closes #838)
+
+## Problem
+Distinct rules can flag the same underlying issue from different angles. For example,
+`rules/stellar/optimization/detect-inefficient-symbol-usage.ts` and
+`rules/stellar/optimization/loops/detect-inefficient-loop.ts` may both report findings that point at the
+same function body, producing duplicate/overlapping recommendations for one root cause.
+
+## Design
+- `packages/rules/soroban/src/correlation/finding-correlator.ts`
+  - Input: `RuleFinding[]` — the same finding shape already emitted by rules such as
+    `detectInefficientSymbolUsage` and `storage-rent-check.ts` (each finding carries a source location
+    and a `message`/`suggestion` pair per the existing convention).
+  - `correlateFindings(findings: RuleFinding[]): CorrelatedGroup[]`
+    - `groupByLocationOverlap`: buckets findings whose source ranges overlap or are adjacent within a
+      configurable line-distance threshold.
+    - `identifyRootCause`: within a bucket, picks a shared root-cause tag (e.g. `redundant-storage-write`,
+      `repeated-allocation`) from a small static tag table keyed by rule id.
+    - Returns `CorrelatedGroup { rootCause: string; findings: RuleFinding[]; consolidatedMessage: string }`.
+- `packages/rules/soroban/src/correlation/finding-correlator.spec.ts` covering: no overlap (groups of 1),
+  two overlapping findings from different rules, and three-way overlap.
+- Consumers: the report generator that currently emits one entry per raw finding switches to iterating
+  `CorrelatedGroup[]`, printing `consolidatedMessage` once per group instead of once per finding.
+
+## Acceptance Criteria
+- [ ] `correlateFindings` groups findings whose source locations overlap.
+- [ ] Overlapping source locations across different rule ids are detected, not just within one rule.
+- [ ] Grouped findings resolve to a shared root-cause tag.
+- [ ] `finding-correlator.spec.ts` covers non-overlap, pairwise, and multi-way correlation cases.

--- a/docs/issue-839-conflict-severity-resolver.md
+++ b/docs/issue-839-conflict-severity-resolver.md
@@ -1,0 +1,30 @@
+# Optimization Conflict Severity Resolver (closes #839)
+
+## Problem
+Rules can recommend mutually exclusive fixes for the same code (e.g. a storage-layout rule under
+`rules/security/storage-layout/` suggesting one packing order while an optimization rule under
+`rules/optimization/storage/` suggests another). Today these conflicting recommendations are surfaced
+with equal weight, giving the user no signal on which to trust.
+
+## Design
+- `packages/rules/soroban/src/conflicts/severity-resolver.ts`
+  - Input: pairs/groups of findings already identified as touching the same location — reusing the
+    `CorrelatedGroup` output from the finding correlator (#838) as the natural source of conflict
+    candidates, plus each finding's existing `confidence` and `estimatedImpact` fields where a rule
+    provides them (as `types.ts` in `packages/gas-estimator/stellar` already models numeric estimates).
+  - `detectConflicts(group: CorrelatedGroup): ConflictPair[]` — flags findings within a group whose
+    suggested fixes are mutually exclusive (e.g. differing target values for the same field/slot).
+  - `resolveSeverity(pair: ConflictPair): ConflictSeverity` — compares `confidence` (higher wins) then
+    `estimatedImpact` (higher wins on a tie), returning `{ severity: 'low'|'medium'|'high', winner, loser,
+    reason }`.
+  - `packages/rules/soroban/src/conflicts/severity-resolver.spec.ts` covering: confidence-decided case,
+    impact-decided tie-break case, and an unresolvable tie (both fields equal) defaulting to `'high'`
+    severity to force human review.
+- Output: `ConflictSeverity.severity` is attached to the consolidated finding surfaced by the formatter
+  (`packages/formatters/src/github-pr-formatter.ts`), replacing the current flat, unranked listing.
+
+## Acceptance Criteria
+- [ ] `detectConflicts` identifies mutually exclusive fixes within a correlated finding group.
+- [ ] `resolveSeverity` factors in each finding's confidence score.
+- [ ] `resolveSeverity` factors in each finding's estimated impact as a tie-breaker.
+- [ ] Resolved severity is included in the analysis output consumed by the formatter.


### PR DESCRIPTION
This PR adds design/spec docs for four related Soroban analysis features, grounded in the existing rule/package structure under packages/rules/soroban, rules/stellar, and packages/formatters.

Closes #812
Resource Profile Generator: aggregates per-contract CPU, memory, and storage estimates from existing findings (storage-rent-check.ts, wasm-inspector.ts) into a single profile with a dominant-category summary.

Closes #837
Rule Dependency Graph: models which rules require output from other rules, validates the graph, detects circular dependencies, and resolves a safe execution order for the rule runner in packages/rules/soroban/src/index.ts.

Closes #838
Cross-Rule Finding Correlator: groups findings from different rules that overlap in source location into a single consolidated finding with a shared root-cause tag, reducing duplicate recommendations.

Closes #839
Optimization Conflict Severity Resolver: when correlated findings suggest mutually exclusive fixes, compares confidence and estimated impact to assign a conflict severity and surface a clear winner.