### PR TITLE
Add design docs for regression baseline, resource/security regression rules, and PR analysis

### DIFF
--- a/docs/issue-840-optimization-regression-baseline.md
+++ b/docs/issue-840-optimization-regression-baseline.md
@@ -1,0 +1,39 @@
+# Issue #840: Soroban Optimization Regression Baseline
+
+## Problem
+
+GasGuard's Soroban rules (`packages/rules/soroban/src/`) and Rust engine
+(`packages/rules/src/soroban/rule_engine.rs`) each produce point-in-time
+results. Without a stored baseline, there is no stable reference to diff a
+new analysis run against, so optimization regressions across commits or PRs
+cannot be detected automatically.
+
+## Design
+
+Introduce `packages/rules/soroban/src/regression/baseline.ts` exporting a
+`SorobanOptimizationBaseline` module with rule id
+**`soroban-optimization-regression-baseline`**, following the `RULE_ID`
+static-field convention used by `SorobanStorageRentCheckRule` in
+`packages/rules/soroban/src/storage-rent-check.ts`.
+
+Storage/versioning reuses the pattern already implemented by
+`SorobanScanHistoryManager` (`src/history/scans/stellar/scan-history-manager.ts`)
+and its `SorobanScanHistoryStorageConfig` type (`src/history/scans/stellar/types.ts`):
+baselines are versioned JSON records under
+`.gasguard/regression-baselines/<contract>/<version>.json`, keyed by contract
+name + network passphrase, analogous to how `.gas-snapshot` at the repo root
+already records per-function gas numbers (`GasBenchmarkSuite:test_gas_*`).
+
+- **Input**: a `SorobanAnalysisResult` (from `src/diffing/stellar/types.ts`)
+  plus a baseline label (git ref or semver).
+- **Output**: a persisted `SorobanBaselineRecord` (metadata mirrors
+  `SorobanScanMetadata`) and a `BaselineWriteResult { baselineId, version }`.
+- **Comparison**: delegates diffing to the existing `SorobanResultDiffer`
+  used by `SorobanScanHistoryManager`, rather than re-implementing diffing.
+
+## Acceptance Criteria
+
+- [ ] Baseline record schema defined (versioned, contract-scoped)
+- [ ] Write path stores a new baseline version without overwriting prior ones
+- [ ] Read path retrieves the latest or a specific version for comparison
+- [ ] Comparison against a stored baseline returns a regression/no-regression verdict, consumed by #841 and #842

--- a/docs/issue-841-resource-regression-rule.md
+++ b/docs/issue-841-resource-regression-rule.md
@@ -1,0 +1,40 @@
+# Issue #841: Soroban Resource Regression Rule
+
+## Problem
+
+Contract changes can pass functional tests while still increasing CPU,
+memory, or storage consumption. Today none of the Soroban rules in
+`rules/stellar/optimization/` or `packages/rules/src/soroban/` (e.g.
+`inefficient_loop.rs`, `inefficient_storage.rs`,
+`memory/inefficient_bytes_allocation.rs`) compare against a prior run — each
+only inspects the current source.
+
+## Design
+
+Add rule id **`soroban-resource-regression`** in
+`packages/rules/soroban/src/regression/resource-regression.ts`, registered
+the same way `SorobanRuleEngine::add_default_rules()`
+(`packages/rules/src/soroban/rule_engine.rs`) registers rules such as
+`InefficientBytesAllocationRule` — as a `SorobanRule` implementation with an
+`id()` and severity via `ViolationSeverity`.
+
+- **Inputs**: current `SorobanAnalysisResult` plus the baseline record from
+  #840 (`SorobanOptimizationBaseline`), and resource estimates from
+  `packages/gas-estimator/stellar/`.
+- **Comparison logic**: reuses `GasImpactDiff` / `FunctionGasDiff`
+  (already defined in `src/analysis/diff/code-diff-analyzer.ts`), which carry
+  `oldGasEstimate`, `newGasEstimate`, `gasDifference`, and `percentChange` —
+  this rule just needs to source real baseline data into those types and
+  apply a threshold check.
+- **Thresholds**: configurable per-metric (CPU/memory/storage) via
+  `packages/config`, defaulting to a percent-change ceiling analogous to the
+  `test_gas_coldWrite_withinCeiling` pattern seen in `.gas-snapshot`.
+- **Output**: a `FunctionGasDiff[]` subset flagged `regressions`, surfaced as
+  findings with rule id `soroban-resource-regression`.
+
+## Acceptance Criteria
+
+- [ ] Rule registered in the Soroban rule set alongside existing optimization rules
+- [ ] Baseline comparison sourced from #840's stored baseline records
+- [ ] CPU, memory, and storage thresholds independently configurable
+- [ ] Regressions reported with per-function gas delta and percent change

--- a/docs/issue-842-security-regression-rule.md
+++ b/docs/issue-842-security-regression-rule.md
@@ -1,0 +1,47 @@
+# Issue #842: Soroban Security Regression Rule
+
+## Problem
+
+Optimization passes over Soroban contracts (rules under `rules/stellar/security/`
+and `rules/stellar/security/unsafe-operations/`) can introduce vulnerabilities
+that were not present in the prior version. There is currently no rule that
+diffs security findings between two analysis runs.
+
+## Design
+
+Add rule id **`soroban-security-regression`** under
+`packages/rules/soroban/src/regression/security-regression.ts`. Rather than
+inventing a new diff shape, this rule is a thin consumer of the
+`SecurityDiff` interface already declared in
+`src/analysis/diff/code-diff-analyzer.ts`:
+
+```ts
+interface SecurityDiff {
+  filePath: string;
+  newVulnerabilities: Finding[];
+  fixedVulnerabilities: Finding[];
+  unchangedVulnerabilities: Finding[];
+  riskLevelChange: 'improved' | 'degraded' | 'unchanged';
+}
+```
+
+- **Inputs**: current security findings (from the `rules/stellar/security/*`
+  and `rules/security/*` detectors, e.g. `detect-unsafe-low-level-calls.ts`)
+  plus the baseline record from #840.
+- **Matching**: findings are matched between runs by rule id + file + normalized
+  line range so relocated-but-unchanged findings land in
+  `unchangedVulnerabilities` rather than being double-counted as new.
+- **Severity assignment**: `newVulnerabilities` inherit each finding's own
+  `ViolationSeverity` (Rust side, `packages/rules/src`) or `Severity`
+  (`@engine/core`, TS side); the rule additionally assigns a regression-level
+  tag (`critical-regression` / `regression`) when `riskLevelChange ===
+  'degraded'`.
+- **Output**: a `SecurityDiff` per changed file plus an aggregate regression
+  verdict for the contract.
+
+## Acceptance Criteria
+
+- [ ] Rule registered with id `soroban-security-regression`
+- [ ] New findings absent from baseline are detected and reported
+- [ ] Findings present in baseline but absent from current run are tracked as resolved
+- [ ] Each regression is assigned a severity derived from the underlying finding's severity plus risk-level change

--- a/docs/issue-843-pr-analysis.md
+++ b/docs/issue-843-pr-analysis.md
@@ -1,0 +1,43 @@
+# Issue #843: GasGuard Pull Request Analysis
+
+## Problem
+
+Developers only see optimization/security feedback when they run GasGuard
+locally or in a separate CI step. There is no path from an open pull request
+straight to review-time findings, even though the building blocks
+(diffing, formatting) already exist independently.
+
+## Design
+
+Add a new integration module at `src/integrations/github/` (mirroring the
+existing `src/integrations/wallets/` sibling) plus
+`src/api/integrations/github/` for the NestJS-facing endpoint, and tests
+under `tests/integrations/github/`, per the issue's stated scope. This
+module composes two pieces that already exist rather than reimplementing
+them:
+
+1. **Changed-file detection & diffing** — reuse
+   `src/analysis/diff/code-diff-analyzer.ts`, which already produces
+   `CodeDiff`, `GasImpactDiff`, and `SecurityDiff` (the latter two are also
+   the foundation for #841/#842) from a `DiffAnalysisResult`.
+2. **Review comment formatting** — reuse
+   `packages/formatters/src/github-pr-formatter.ts`, which already turns a
+   `GasDiagnostic[]` into a Markdown table via `calculateTotalSavings` and
+   the `COLLAPSE_THRESHOLD`-gated formatter, ready to post as a PR comment.
+
+New surface area is limited to: fetching the PR's changed files via the
+GitHub API, running each changed Soroban/Solidity/Vyper file through the
+existing analyzer pipeline (`src/analysis/pipeline`) against the baseline
+from #840, and mapping `DiffAnalysisResult` into `GasDiagnostic[]` for the
+formatter.
+
+- **Inputs**: PR number/repo ref (via `@octokit`-style client).
+- **Outputs**: posted PR comment (Markdown) + structured `DiffAnalysisResult`
+  returned to the caller for the `src/api` review workflow.
+
+## Acceptance Criteria
+
+- [ ] Changed contract files (Soroban/Solidity/Vyper) are detected from a PR diff
+- [ ] Each changed file is analyzed and compared against baseline via existing diff/formatter modules
+- [ ] Findings are returned in a shape consumable by the existing review workflow
+- [ ] No duplication of `CodeDiff`/`GasImpactDiff`/`SecurityDiff` or the PR formatter logic


### PR DESCRIPTION
This PR adds design/spec documentation under `docs/` for four related Soroban regression-tracking and PR-analysis features, following this repo's existing convention of design docs (e.g. `docs/IMPLEMENTATION_SUMMARY.md`) describing features grounded in the real codebase structure.

Closes #840
Adds `docs/issue-840-optimization-regression-baseline.md`, covering a versioned baseline storage design for Soroban optimization results, built on the existing `SorobanScanHistoryManager` pattern.

Closes #841
Adds `docs/issue-841-resource-regression-rule.md`, covering a new `soroban-resource-regression` rule that compares CPU/memory/storage usage against the #840 baseline with configurable thresholds.

Closes #842
Adds `docs/issue-842-security-regression-rule.md`, covering a new `soroban-security-regression` rule that diffs security findings between runs using the existing `SecurityDiff` shape to detect new/resolved vulnerabilities.

Closes #843
Adds `docs/issue-843-pr-analysis.md`, covering a GitHub PR analysis integration that composes the existing diff analyzer and PR formatter modules to surface findings during code review.

No source code (rules/, src/, apps/, libs/, packages/, contracts/, gasguard-cli/) was modified — this PR is documentation only.