### PR TITLE
feat(soroban): detect unnecessary token transfers and redundant balan…

### DIFF
--- a/packages/analyzers/soroban/callgraph/__tests__/token-transfer-analyzer.spec.ts
+++ b/packages/analyzers/soroban/callgraph/__tests__/token-transfer-analyzer.spec.ts
@@ -1,0 +1,308 @@
+import {
+  analyzeTokenTransfers,
+  buildTransferEdges,
+  extractTransfers,
+  traceTransferPaths,
+} from '../token-transfer-analyzer';
+
+const REPEATED_TRANSFERS = `
+pub fn pay_fees(env: Env, token: Address, user: Address, treasury: Address) {
+    let client = token::Client::new(&env, &token);
+    client.transfer(&user, &treasury, &base_fee);
+    client.transfer(&user, &treasury, &priority_fee);
+    client.transfer(&user, &treasury, &tip);
+}
+`;
+
+const RELAY_CHAIN = `
+pub fn route(env: Env, token: Address, user: Address, escrow: Address, merchant: Address) {
+    let client = token::Client::new(&env, &token);
+    client.transfer(&user, &escrow, &amount);
+    client.transfer(&escrow, &merchant, &amount);
+}
+`;
+
+const GUARDED_TRANSFERS = `
+pub fn withdraw(env: Env, token: Address, user: Address, treasury: Address) {
+    let client = token::Client::new(&env, &token);
+    client.transfer(&user, &treasury, &first);
+    user.require_auth();
+    client.transfer(&user, &treasury, &second);
+}
+`;
+
+const BRANCHED_TRANSFERS = `
+pub fn settle(env: Env, token: Address, user: Address, treasury: Address) {
+    let client = token::Client::new(&env, &token);
+    if is_premium {
+        client.transfer(&user, &treasury, &premium_fee);
+    } else {
+        client.transfer(&user, &treasury, &standard_fee);
+    }
+}
+`;
+
+const LOOPED_TRANSFERS = `
+pub fn payout(env: Env, token: Address, vault: Address, winner: Address) {
+    let client = token::Client::new(&env, &token);
+    for _ in 0..rounds {
+        client.transfer(&vault, &winner, &share);
+    }
+    client.transfer(&vault, &winner, &bonus);
+}
+`;
+
+const CLEAN = `
+pub fn single_payment(env: Env, token: Address, user: Address, treasury: Address) {
+    let client = token::Client::new(&env, &token);
+    client.transfer(&user, &treasury, &amount);
+}
+`;
+
+describe('TokenTransferAnalyzer', () => {
+  describe('transfer extraction', () => {
+    it('extracts transfer sites with resolved token, source and destination', () => {
+      const transfers = extractTransfers(REPEATED_TRANSFERS);
+
+      expect(transfers).toHaveLength(3);
+      expect(transfers[0]).toMatchObject({
+        fn: 'pay_fees',
+        token: 'token',
+        method: 'transfer',
+        from: 'user',
+        to: 'treasury',
+        amount: 'base_fee',
+      });
+    });
+
+    it('resolves the token for the inline Client::new form', () => {
+      const transfers = extractTransfers(`
+        pub fn tip(env: Env) {
+            token::Client::new(&env, &usdc).transfer(&payer, &author, &amount);
+        }
+      `);
+
+      expect(transfers).toHaveLength(1);
+      expect(transfers[0].token).toBe('usdc');
+      expect(transfers[0].to).toBe('author');
+    });
+
+    it('reads the from/to slots of transfer_from correctly', () => {
+      const transfers = extractTransfers(`
+        pub fn pull(env: Env) {
+            let client = token::Client::new(&env, &token);
+            client.transfer_from(&spender, &owner, &vault, &amount);
+        }
+      `);
+
+      expect(transfers[0]).toMatchObject({ from: 'owner', to: 'vault', amount: 'amount' });
+    });
+
+    it('normalizes clone()/borrow noise so identical destinations match', () => {
+      const transfers = extractTransfers(`
+        pub fn twice(env: Env) {
+            let client = token::Client::new(&env, &token);
+            client.transfer(&user, &treasury.clone(), &a);
+            client.transfer(&user.clone(), &treasury, &b);
+        }
+      `);
+
+      expect(transfers[0].to).toBe(transfers[1].to);
+      expect(transfers[0].from).toBe(transfers[1].from);
+    });
+
+    it('ignores transfers appearing in comments or string literals', () => {
+      const transfers = extractTransfers(`
+        pub fn documented(env: Env) {
+            // client.transfer(&user, &treasury, &amount);
+            let note = "client.transfer(&user, &treasury, &amount)";
+        }
+      `);
+
+      expect(transfers).toHaveLength(0);
+    });
+  });
+
+  describe('transfer paths', () => {
+    it('builds directed edges and counts repeats', () => {
+      const edges = buildTransferEdges(extractTransfers(REPEATED_TRANSFERS));
+
+      expect(edges).toHaveLength(1);
+      expect(edges[0]).toMatchObject({ from: 'user', to: 'treasury', count: 3 });
+      expect(edges[0].lines).toHaveLength(3);
+    });
+
+    it('traces multi-hop transfer paths through an intermediate holder', () => {
+      const paths = traceTransferPaths(extractTransfers(RELAY_CHAIN));
+
+      expect(paths).toHaveLength(1);
+      expect(paths[0].hops).toEqual(['user', 'escrow', 'merchant']);
+    });
+
+    it('does not link hops across different tokens', () => {
+      const paths = traceTransferPaths(
+        extractTransfers(`
+          pub fn mixed(env: Env) {
+              let a = token::Client::new(&env, &usdc);
+              let b = token::Client::new(&env, &eurc);
+              a.transfer(&user, &escrow, &amount);
+              b.transfer(&escrow, &merchant, &amount);
+          }
+        `),
+      );
+
+      expect(paths).toHaveLength(0);
+    });
+  });
+
+  describe('redundant transfer detection', () => {
+    it('flags repeated transfers on the same edge and suggests consolidation', () => {
+      const { findings } = analyzeTokenTransfers(REPEATED_TRANSFERS);
+      const redundant = findings.find((f) => f.ruleId === 'soroban-redundant-token-transfer');
+
+      expect(redundant).toBeDefined();
+      expect(redundant!.severity).toBe('high');
+      expect(redundant!.preserved).toBe(false);
+      expect(redundant!.relatedLines).toHaveLength(2);
+      expect(redundant!.suggestion).toContain('single transfer');
+      expect(redundant!.suggestion).toContain('base_fee + priority_fee + tip');
+    });
+
+    it('suggests a direct transfer when funds relay through an intermediate', () => {
+      const { findings } = analyzeTokenTransfers(RELAY_CHAIN);
+      const relay = findings.find((f) => f.ruleId === 'soroban-intermediate-token-transfer');
+
+      expect(relay).toBeDefined();
+      expect(relay!.preserved).toBe(false);
+      expect(relay!.message).toContain('user → escrow → merchant');
+      expect(relay!.suggestion).toContain("directly from 'user' to 'merchant'");
+    });
+
+    it('preserves a relay whose hops move different amounts', () => {
+      const { findings } = analyzeTokenTransfers(`
+        pub fn skim(env: Env) {
+            let client = token::Client::new(&env, &token);
+            client.transfer(&user, &escrow, &gross);
+            client.transfer(&escrow, &merchant, &net);
+        }
+      `);
+      const relay = findings.find((f) => f.ruleId === 'soroban-intermediate-token-transfer');
+
+      expect(relay!.preserved).toBe(true);
+      expect(relay!.severity).toBe('info');
+    });
+
+    it('flags self-transfers as removable', () => {
+      const { findings } = analyzeTokenTransfers(`
+        pub fn noop(env: Env) {
+            let client = token::Client::new(&env, &token);
+            client.transfer(&user, &user, &amount);
+        }
+      `);
+
+      const self = findings.find((f) => f.ruleId === 'soroban-self-token-transfer');
+      expect(self).toBeDefined();
+      expect(self!.preserved).toBe(false);
+    });
+
+    it('flags hard-coded zero-amount transfers', () => {
+      const { findings } = analyzeTokenTransfers(`
+        pub fn ping(env: Env) {
+            let client = token::Client::new(&env, &token);
+            client.transfer(&user, &treasury, &0i128);
+        }
+      `);
+
+      expect(findings.some((f) => f.ruleId === 'soroban-zero-token-transfer')).toBe(true);
+    });
+
+    it('reports nothing for a contract with a single transfer', () => {
+      const report = analyzeTokenTransfers(CLEAN);
+
+      expect(report.transfers).toHaveLength(1);
+      expect(report.findings).toHaveLength(0);
+    });
+  });
+
+  describe('security-sensitive preservation', () => {
+    it('preserves transfers separated by an authorization check', () => {
+      const { findings } = analyzeTokenTransfers(GUARDED_TRANSFERS);
+      const redundant = findings.find((f) => f.ruleId === 'soroban-redundant-token-transfer');
+
+      expect(redundant!.preserved).toBe(true);
+      expect(redundant!.severity).toBe('info');
+      expect(redundant!.preservedReason).toContain('authorization');
+      expect(redundant!.suggestion).not.toContain('single transfer');
+    });
+
+    it('preserves transfers on mutually exclusive branches', () => {
+      const { findings } = analyzeTokenTransfers(BRANCHED_TRANSFERS);
+      const redundant = findings.find((f) => f.ruleId === 'soroban-redundant-token-transfer');
+
+      expect(redundant!.preserved).toBe(true);
+      expect(redundant!.preservedReason).toContain('conditional');
+    });
+
+    it('preserves transfers whose repeat count is loop-driven', () => {
+      const { findings } = analyzeTokenTransfers(LOOPED_TRANSFERS);
+      const redundant = findings.find((f) => f.ruleId === 'soroban-redundant-token-transfer');
+
+      expect(redundant!.preserved).toBe(true);
+      expect(redundant!.preservedReason).toContain('loop');
+    });
+
+    it('still consolidates repeats separated by a non-security statement', () => {
+      const { findings } = analyzeTokenTransfers(`
+        pub fn batch(env: Env) {
+            let client = token::Client::new(&env, &token);
+            client.transfer(&user, &treasury, &a);
+            log("paid part one");
+            client.transfer(&user, &treasury, &b);
+        }
+      `);
+      const redundant = findings.find((f) => f.ruleId === 'soroban-redundant-token-transfer');
+
+      expect(redundant!.preserved).toBe(false);
+    });
+  });
+
+  describe('report metrics', () => {
+    it('summarizes transfer counts and opportunities', () => {
+      const report = analyzeTokenTransfers(REPEATED_TRANSFERS);
+
+      expect(report.metrics.totalTransfers).toBe(3);
+      expect(report.metrics.uniqueEdges).toBe(1);
+      expect(report.metrics.redundantTransfers).toBe(2);
+      expect(report.metrics.consolidationOpportunities).toBeGreaterThan(0);
+    });
+
+    it('counts preserved findings separately', () => {
+      const report = analyzeTokenTransfers(GUARDED_TRANSFERS);
+
+      expect(report.metrics.preservedTransfers).toBeGreaterThan(0);
+      expect(report.metrics.consolidationOpportunities).toBe(0);
+    });
+
+    it('keeps transfers in separate functions apart', () => {
+      const report = analyzeTokenTransfers(`
+        pub fn one(env: Env) {
+            let client = token::Client::new(&env, &token);
+            client.transfer(&user, &treasury, &amount);
+        }
+        pub fn two(env: Env) {
+            let client = token::Client::new(&env, &token);
+            client.transfer(&user, &treasury, &amount);
+        }
+      `);
+
+      expect(report.edges).toHaveLength(2);
+      expect(report.findings).toHaveLength(0);
+    });
+
+    it('handles empty source without throwing', () => {
+      const report = analyzeTokenTransfers('');
+      expect(report.transfers).toHaveLength(0);
+      expect(report.findings).toHaveLength(0);
+    });
+  });
+});

--- a/packages/analyzers/soroban/callgraph/token-transfer-analyzer.ts
+++ b/packages/analyzers/soroban/callgraph/token-transfer-analyzer.ts
@@ -1,0 +1,397 @@
+/**
+ * Soroban Token Transfer Analyzer
+ *
+ * Detects token transfers that can be avoided or consolidated:
+ *  - repeated transfers along the same (token, from → to) edge
+ *  - relay chains where funds hop through an intermediate holder (A → B → C)
+ *  - self-transfers and zero-amount transfers, which are pure overhead
+ *
+ * Every suggestion is gated on a safety check: transfers on mutually exclusive
+ * branches, transfers separated by an authorization or state check, and
+ * transfers inside loops are reported as `preserved` and never proposed for
+ * consolidation, because collapsing them would change the contract's
+ * security-relevant behaviour.
+ */
+
+import {
+  BlockFrame,
+  blockStackAt,
+  createLineResolver,
+  extractArgs,
+  extractFunctions,
+  isInLoop,
+  maskNonCode,
+  normalizeExpr,
+  onExclusiveBranches,
+  receiverBefore,
+  resolveTokenBindings,
+  resolveTokenFromReceiver,
+  splitArgs,
+} from '../common/source-utils';
+
+export type Severity = 'high' | 'medium' | 'low' | 'info';
+
+/** Transfer-shaped token methods and the argument slots they use. */
+const TRANSFER_METHODS: Record<string, { from: number; to: number; amount: number }> = {
+  transfer: { from: 0, to: 1, amount: 2 },
+  transfer_from: { from: 1, to: 2, amount: 3 },
+  // `mint`/`burn` move value but have no `from`/`to` pair; handled separately.
+};
+
+/** Calls that mint or destroy supply — value-moving, but not consolidatable. */
+const SUPPLY_METHODS = new Set(['mint', 'burn', 'burn_from', 'clawback']);
+
+/** Calls whose presence between two transfers makes consolidation unsafe. */
+const SECURITY_CHECK_PATTERN =
+  /\b(require_auth|require_auth_for_args|authorize_as_current_contract|check_auth|panic_with_error|assert!|assert_eq!|require!|unwrap_or_else)\s*[(!]/;
+
+export interface TransferSite {
+  /** Enclosing function name. */
+  fn: string;
+  /** Token contract the transfer targets (resolved from the client binding). */
+  token: string;
+  /** Method name: `transfer` or `transfer_from`. */
+  method: string;
+  /** Normalized source account expression. */
+  from: string;
+  /** Normalized destination account expression. */
+  to: string;
+  /** Normalized amount expression. */
+  amount: string;
+  line: number;
+  /** Character offset of the call site. */
+  offset: number;
+  /** Enclosing block frames, used for branch/loop safety checks. */
+  stack: BlockFrame[];
+  /** True when the transfer executes inside a loop body. */
+  inLoop: boolean;
+}
+
+/** A directed edge in the transfer graph of a single function. */
+export interface TransferEdge {
+  fn: string;
+  token: string;
+  from: string;
+  to: string;
+  /** Number of transfers along this edge. */
+  count: number;
+  lines: number[];
+  amounts: string[];
+}
+
+export interface TransferPath {
+  fn: string;
+  token: string;
+  /** Ordered account hops, e.g. `['user', 'contract', 'treasury']`. */
+  hops: string[];
+  lines: number[];
+}
+
+export interface TokenTransferFinding {
+  ruleId:
+    | 'soroban-redundant-token-transfer'
+    | 'soroban-intermediate-token-transfer'
+    | 'soroban-self-token-transfer'
+    | 'soroban-zero-token-transfer';
+  severity: Severity;
+  line: number;
+  /** Other lines participating in the same finding. */
+  relatedLines: number[];
+  fn: string;
+  token: string;
+  message: string;
+  suggestion: string;
+  /**
+   * True when the transfers were left intact on purpose: an auth check, an
+   * exclusive branch or a loop makes consolidation security-sensitive.
+   */
+  preserved: boolean;
+  /** Why the finding was preserved rather than proposed for consolidation. */
+  preservedReason?: string;
+}
+
+export interface TokenTransferReport {
+  transfers: TransferSite[];
+  edges: TransferEdge[];
+  paths: TransferPath[];
+  findings: TokenTransferFinding[];
+  metrics: {
+    totalTransfers: number;
+    uniqueEdges: number;
+    redundantTransfers: number;
+    consolidationOpportunities: number;
+    preservedTransfers: number;
+  };
+}
+
+/**
+ * Extract every token transfer call site from Soroban Rust source.
+ */
+export function extractTransfers(source: string): TransferSite[] {
+  const masked = maskNonCode(source);
+  const lineOf = createLineResolver(source);
+  const bindings = resolveTokenBindings(masked, source);
+  const functions = extractFunctions(masked, source);
+  const sites: TransferSite[] = [];
+
+  const methodNames = Object.keys(TRANSFER_METHODS).join('|');
+  const callRe = new RegExp(`\\.\\s*(${methodNames})\\s*\\(`, 'g');
+
+  let m: RegExpExecArray | null;
+  while ((m = callRe.exec(masked)) !== null) {
+    const method = m[1];
+    const slots = TRANSFER_METHODS[method];
+    const openParen = m.index + m[0].length - 1;
+    const args = splitArgs(extractArgs(masked, source, openParen).text);
+
+    // A real transfer supplies at least the destination and amount.
+    if (args.length <= slots.amount) continue;
+
+    const enclosing = functions.find(
+      (f) => m!.index >= f.bodyStart && m!.index < f.bodyEnd,
+    );
+    if (!enclosing) continue;
+
+    const receiver = receiverBefore(source, m.index);
+    const stack = blockStackAt(masked, enclosing.bodyStart, m.index);
+
+    sites.push({
+      fn: enclosing.name,
+      token: resolveTokenFromReceiver(receiver, bindings),
+      method,
+      from: normalizeExpr(args[slots.from]),
+      to: normalizeExpr(args[slots.to]),
+      amount: normalizeExpr(args[slots.amount]),
+      line: lineOf(m.index),
+      offset: m.index,
+      stack,
+      inLoop: isInLoop(stack),
+    });
+  }
+
+  return sites.sort((a, b) => a.offset - b.offset);
+}
+
+/**
+ * Collapse transfer sites into the directed edges of a per-function graph.
+ */
+export function buildTransferEdges(transfers: TransferSite[]): TransferEdge[] {
+  const edges = new Map<string, TransferEdge>();
+
+  for (const t of transfers) {
+    const key = `${t.fn}|${t.token}|${t.from}->${t.to}`;
+    let edge = edges.get(key);
+    if (!edge) {
+      edge = { fn: t.fn, token: t.token, from: t.from, to: t.to, count: 0, lines: [], amounts: [] };
+      edges.set(key, edge);
+    }
+    edge.count += 1;
+    edge.lines.push(t.line);
+    edge.amounts.push(t.amount);
+  }
+
+  return Array.from(edges.values()).sort((a, b) => b.count - a.count);
+}
+
+/**
+ * Trace multi-hop transfer paths — a destination that is itself the source of a
+ * later transfer of the same token within the same function.
+ */
+export function traceTransferPaths(transfers: TransferSite[]): TransferPath[] {
+  const paths: TransferPath[] = [];
+
+  for (let i = 0; i < transfers.length; i++) {
+    const first = transfers[i];
+
+    for (let j = i + 1; j < transfers.length; j++) {
+      const second = transfers[j];
+      if (second.fn !== first.fn || second.token !== first.token) continue;
+      if (second.from !== first.to) continue;
+      if (first.to === first.from || second.to === second.from) continue;
+
+      paths.push({
+        fn: first.fn,
+        token: first.token,
+        hops: [first.from, first.to, second.to],
+        lines: [first.line, second.line],
+      });
+    }
+  }
+
+  return paths;
+}
+
+/**
+ * Decide whether two transfer sites may be consolidated, and if not, why.
+ */
+function consolidationBlocker(
+  source: string,
+  a: TransferSite,
+  b: TransferSite,
+): string | undefined {
+  if (a.inLoop || b.inLoop) {
+    return 'transfer executes inside a loop, so the number of transfers is data-dependent';
+  }
+  if (onExclusiveBranches(a.stack, b.stack)) {
+    return 'transfers sit on different conditional paths and may not both execute';
+  }
+
+  const between = source.slice(a.offset, b.offset);
+  if (SECURITY_CHECK_PATTERN.test(between)) {
+    return 'an authorization or assertion between the transfers may depend on the first having settled';
+  }
+
+  return undefined;
+}
+
+/**
+ * Detect transfers that are redundant, avoidable, or worth consolidating.
+ */
+export function detectTransferIssues(
+  source: string,
+  transfers: TransferSite[],
+  paths: TransferPath[],
+): TokenTransferFinding[] {
+  const findings: TokenTransferFinding[] = [];
+
+  // Self-transfers and zero-amount transfers: always removable.
+  for (const t of transfers) {
+    if (t.from === t.to && t.from.length > 0) {
+      findings.push({
+        ruleId: 'soroban-self-token-transfer',
+        severity: 'medium',
+        line: t.line,
+        relatedLines: [],
+        fn: t.fn,
+        token: t.token,
+        message: `Transfer of token '${t.token}' in '${t.fn}' sends from and to the same address '${t.from}'.`,
+        suggestion: 'Remove the self-transfer — it changes no balance but still pays the full contract-call cost.',
+        preserved: false,
+      });
+    }
+
+    if (/^0(?:i128|u128|i64|u64)?$/.test(t.amount)) {
+      findings.push({
+        ruleId: 'soroban-zero-token-transfer',
+        severity: 'low',
+        line: t.line,
+        relatedLines: [],
+        fn: t.fn,
+        token: t.token,
+        message: `Transfer of token '${t.token}' in '${t.fn}' moves a hard-coded zero amount.`,
+        suggestion: 'Drop the zero-amount transfer, or guard it behind an `if amount > 0` check.',
+        preserved: false,
+      });
+    }
+  }
+
+  // Repeated transfers along an identical (token, from → to) edge.
+  const groups = new Map<string, TransferSite[]>();
+  for (const t of transfers) {
+    if (t.from === t.to) continue; // already reported as a self-transfer
+    const key = `${t.fn}|${t.token}|${t.from}->${t.to}`;
+    const list = groups.get(key) ?? [];
+    list.push(t);
+    groups.set(key, list);
+  }
+
+  for (const group of groups.values()) {
+    if (group.length < 2) continue;
+
+    const [first] = group;
+    const blockers = group
+      .slice(1)
+      .map((t) => consolidationBlocker(source, first, t))
+      .filter((r): r is string => r !== undefined);
+
+    const lines = group.map((t) => t.line);
+    const preserved = blockers.length > 0;
+
+    findings.push({
+      ruleId: 'soroban-redundant-token-transfer',
+      severity: preserved ? 'info' : group.length >= 3 ? 'high' : 'medium',
+      line: first.line,
+      relatedLines: lines.slice(1),
+      fn: first.fn,
+      token: first.token,
+      message:
+        `Token '${first.token}' is transferred from '${first.from}' to '${first.to}' ` +
+        `${group.length} times in '${first.fn}' (lines: ${lines.join(', ')}).`,
+      suggestion: preserved
+        ? `Left as-is: ${blockers[0]}. Verify the repetition is intentional before merging these transfers.`
+        : `Sum the amounts (${group.map((t) => t.amount).join(' + ')}) and issue a single transfer to '${first.to}', saving ${group.length - 1} contract call(s).`,
+      preserved,
+      preservedReason: blockers[0],
+    });
+  }
+
+  // Relay chains: A → B → C with the same token and amount.
+  const seenPaths = new Set<string>();
+  for (const path of paths) {
+    const key = `${path.fn}|${path.token}|${path.hops.join('->')}`;
+    if (seenPaths.has(key)) continue;
+    seenPaths.add(key);
+
+    const [firstLine, secondLine] = path.lines;
+    const a = transfers.find((t) => t.line === firstLine && t.fn === path.fn);
+    const b = transfers.find((t) => t.line === secondLine && t.fn === path.fn);
+    if (!a || !b) continue;
+
+    const blocker = consolidationBlocker(source, a, b);
+    // Amounts must match for a direct transfer to be equivalent.
+    const sameAmount = a.amount === b.amount;
+    const preserved = blocker !== undefined || !sameAmount;
+
+    findings.push({
+      ruleId: 'soroban-intermediate-token-transfer',
+      severity: preserved ? 'info' : 'medium',
+      line: firstLine,
+      relatedLines: [secondLine],
+      fn: path.fn,
+      token: path.token,
+      message:
+        `Token '${path.token}' hops through intermediate holder '${path.hops[1]}' ` +
+        `(${path.hops.join(' → ')}) in '${path.fn}' at lines ${path.lines.join(', ')}.`,
+      suggestion: preserved
+        ? `Left as-is: ${blocker ?? 'the two hops move different amounts, so the intermediate balance is load-bearing'}.`
+        : `Transfer directly from '${path.hops[0]}' to '${path.hops[2]}' if '${path.hops[1]}' does not need custody, removing one contract call.`,
+      preserved,
+      preservedReason: blocker ?? (sameAmount ? undefined : 'hops move different amounts'),
+    });
+  }
+
+  return findings.sort((a, b) => a.line - b.line);
+}
+
+/**
+ * Full analysis entry point.
+ */
+export function analyzeTokenTransfers(source: string): TokenTransferReport {
+  const transfers = extractTransfers(source);
+  const edges = buildTransferEdges(transfers);
+  const paths = traceTransferPaths(transfers);
+  const findings = detectTransferIssues(source, transfers, paths);
+
+  const redundantTransfers = edges
+    .filter((e) => e.count > 1)
+    .reduce((sum, e) => sum + (e.count - 1), 0);
+
+  return {
+    transfers,
+    edges,
+    paths,
+    findings,
+    metrics: {
+      totalTransfers: transfers.length,
+      uniqueEdges: edges.length,
+      redundantTransfers,
+      consolidationOpportunities: findings.filter((f) => !f.preserved).length,
+      preservedTransfers: findings.filter((f) => f.preserved).length,
+    },
+  };
+}
+
+/** Exposed for callers that want to flag supply-changing token calls. */
+export function isSupplyMethod(method: string): boolean {
+  return SUPPLY_METHODS.has(method);
+}

--- a/packages/analyzers/soroban/calls/__tests__/balance-query-analyzer.spec.ts
+++ b/packages/analyzers/soroban/calls/__tests__/balance-query-analyzer.spec.ts
@@ -1,0 +1,321 @@
+import {
+  analyzeBalanceQueries,
+  extractBalanceQueries,
+  generateBalanceFindings,
+  groupBalanceQueries,
+} from '../balance-query-analyzer';
+
+const REPEATED_QUERIES = `
+pub fn quote(env: Env, token: Address, user: Address) -> i128 {
+    let client = token::Client::new(&env, &token);
+    let a = client.balance(&user);
+    let b = client.balance(&user);
+    let c = client.balance(&user);
+    a + b + c
+}
+`;
+
+const MUTATED_BETWEEN = `
+pub fn settle(env: Env, token: Address, user: Address, treasury: Address) {
+    let client = token::Client::new(&env, &token);
+    let before = client.balance(&user);
+    client.transfer(&user, &treasury, &fee);
+    let after = client.balance(&user);
+}
+`;
+
+const DIFFERENT_ACCOUNTS = `
+pub fn compare(env: Env, token: Address, user: Address, treasury: Address) {
+    let client = token::Client::new(&env, &token);
+    let a = client.balance(&user);
+    let b = client.balance(&treasury);
+}
+`;
+
+const LOOPED_QUERY = `
+pub fn distribute(env: Env, token: Address, vault: Address) {
+    let client = token::Client::new(&env, &token);
+    for _ in 0..rounds {
+        let available = client.balance(&vault);
+        pay_out(available);
+    }
+}
+`;
+
+describe('BalanceQueryAnalyzer', () => {
+  describe('query extraction', () => {
+    it('extracts balance reads with resolved asset and account inputs', () => {
+      const queries = extractBalanceQueries(REPEATED_QUERIES);
+
+      expect(queries).toHaveLength(3);
+      expect(queries[0]).toMatchObject({
+        fn: 'quote',
+        asset: 'token',
+        account: 'user',
+        method: 'balance',
+      });
+    });
+
+    it('extracts free-function balance reads keyed on the account argument', () => {
+      const queries = extractBalanceQueries(`
+        pub fn check(env: Env, user: Address) {
+            let a = read_balance(&env, &user);
+            let b = read_balance(&env, &user);
+        }
+      `);
+
+      expect(queries).toHaveLength(2);
+      expect(queries[0]).toMatchObject({ asset: 'self', account: 'user', method: 'read_balance' });
+    });
+
+    it('recognises balance_of and spendable_balance reads', () => {
+      const queries = extractBalanceQueries(`
+        pub fn check(env: Env, token: Address, user: Address) {
+            let client = token::Client::new(&env, &token);
+            let a = client.balance_of(&user);
+            let b = client.spendable_balance(&user);
+        }
+      `);
+
+      expect(queries.map((q) => q.method)).toEqual(['balance_of', 'spendable_balance']);
+    });
+
+    it('resolves the asset for the inline Client::new form', () => {
+      const queries = extractBalanceQueries(`
+        pub fn check(env: Env, user: Address) {
+            let a = token::Client::new(&env, &usdc).balance(&user);
+        }
+      `);
+
+      expect(queries[0].asset).toBe('usdc');
+    });
+
+    it('ignores balance reads in comments and string literals', () => {
+      const queries = extractBalanceQueries(`
+        pub fn documented(env: Env) {
+            // let a = client.balance(&user);
+            let note = "client.balance(&user)";
+        }
+      `);
+
+      expect(queries).toHaveLength(0);
+    });
+  });
+
+  describe('input comparison', () => {
+    it('groups reads sharing the same asset and account', () => {
+      const groups = groupBalanceQueries(REPEATED_QUERIES, extractBalanceQueries(REPEATED_QUERIES));
+
+      expect(groups).toHaveLength(1);
+      expect(groups[0]).toMatchObject({ asset: 'token', account: 'user', count: 3 });
+    });
+
+    it('keeps reads for different accounts in separate groups', () => {
+      const groups = groupBalanceQueries(
+        DIFFERENT_ACCOUNTS,
+        extractBalanceQueries(DIFFERENT_ACCOUNTS),
+      );
+
+      expect(groups).toHaveLength(2);
+      expect(groups.every((g) => g.count === 1)).toBe(true);
+    });
+
+    it('keeps reads for different assets in separate groups', () => {
+      const source = `
+        pub fn compare(env: Env, user: Address) {
+            let a = token::Client::new(&env, &usdc).balance(&user);
+            let b = token::Client::new(&env, &eurc).balance(&user);
+        }
+      `;
+      const groups = groupBalanceQueries(source, extractBalanceQueries(source));
+
+      expect(groups).toHaveLength(2);
+    });
+
+    it('treats clone()/borrow variants of the same account as identical inputs', () => {
+      const source = `
+        pub fn dup(env: Env, token: Address, user: Address) {
+            let client = token::Client::new(&env, &token);
+            let a = client.balance(&user);
+            let b = client.balance(&user.clone());
+        }
+      `;
+      const groups = groupBalanceQueries(source, extractBalanceQueries(source));
+
+      expect(groups).toHaveLength(1);
+      expect(groups[0].count).toBe(2);
+    });
+  });
+
+  describe('safe reuse detection', () => {
+    it('marks repeats with no intervening mutation as reusable', () => {
+      const groups = groupBalanceQueries(REPEATED_QUERIES, extractBalanceQueries(REPEATED_QUERIES));
+
+      expect(groups[0].safeToReuse).toBe(true);
+      expect(groups[0].invalidatedBy).toBeUndefined();
+    });
+
+    it('marks repeats separated by a transfer as not reusable', () => {
+      const groups = groupBalanceQueries(MUTATED_BETWEEN, extractBalanceQueries(MUTATED_BETWEEN));
+
+      expect(groups[0].safeToReuse).toBe(false);
+      expect(groups[0].invalidatedBy).toBe('token transfer');
+      expect(groups[0].invalidatedAtLine).toBeGreaterThan(groups[0].lines[0]);
+    });
+
+    it('marks repeats separated by a mint as not reusable', () => {
+      const source = `
+        pub fn grant(env: Env, token: Address, user: Address) {
+            let client = token::Client::new(&env, &token);
+            let before = client.balance(&user);
+            client.mint(&user, &reward);
+            let after = client.balance(&user);
+        }
+      `;
+      const groups = groupBalanceQueries(source, extractBalanceQueries(source));
+
+      expect(groups[0].safeToReuse).toBe(false);
+      expect(groups[0].invalidatedBy).toBe('token mint');
+    });
+
+    it('marks repeats separated by a storage write as not reusable', () => {
+      const source = `
+        pub fn touch(env: Env, user: Address) {
+            let before = read_balance(&env, &user);
+            env.storage().persistent().set(&key, &value);
+            let after = read_balance(&env, &user);
+        }
+      `;
+      const groups = groupBalanceQueries(source, extractBalanceQueries(source));
+
+      expect(groups[0].safeToReuse).toBe(false);
+      expect(groups[0].invalidatedBy).toBe('storage write');
+    });
+
+    it('marks reads on different conditional paths as not reusable', () => {
+      const source = `
+        pub fn branchy(env: Env, token: Address, user: Address) {
+            let client = token::Client::new(&env, &token);
+            if is_premium {
+                let a = client.balance(&user);
+            } else {
+                let b = client.balance(&user);
+            }
+        }
+      `;
+      const groups = groupBalanceQueries(source, extractBalanceQueries(source));
+
+      expect(groups[0].safeToReuse).toBe(false);
+      expect(groups[0].invalidatedBy).toContain('conditional');
+    });
+  });
+
+  describe('finding generation', () => {
+    it('flags redundant reusable queries with a caching suggestion', () => {
+      const { findings } = analyzeBalanceQueries(REPEATED_QUERIES);
+      const redundant = findings.find((f) => f.ruleId === 'soroban-redundant-balance-query');
+
+      expect(redundant).toBeDefined();
+      expect(redundant!.safeToReuse).toBe(true);
+      expect(redundant!.severity).toBe('medium');
+      expect(redundant!.relatedLines).toHaveLength(2);
+      expect(redundant!.suggestion).toContain('local variable');
+    });
+
+    it('downgrades and explains queries that must be re-read', () => {
+      const { findings } = analyzeBalanceQueries(MUTATED_BETWEEN);
+      const redundant = findings.find((f) => f.ruleId === 'soroban-redundant-balance-query');
+
+      expect(redundant!.safeToReuse).toBe(false);
+      expect(redundant!.severity).toBe('info');
+      expect(redundant!.suggestion).toContain('Keep the re-read');
+      expect(redundant!.suggestion).toContain('token transfer');
+    });
+
+    it('escalates severity as the query count grows', () => {
+      const source = `
+        pub fn hot(env: Env, token: Address, user: Address) {
+            let client = token::Client::new(&env, &token);
+            let a = client.balance(&user);
+            let b = client.balance(&user);
+            let c = client.balance(&user);
+            let d = client.balance(&user);
+        }
+      `;
+      const { findings } = analyzeBalanceQueries(source);
+
+      expect(findings[0].severity).toBe('high');
+    });
+
+    it('flags a balance read inside a loop even when read only once', () => {
+      const { findings } = analyzeBalanceQueries(LOOPED_QUERY);
+      const inLoop = findings.find((f) => f.ruleId === 'soroban-balance-query-in-loop');
+
+      expect(inLoop).toBeDefined();
+      expect(inLoop!.severity).toBe('high');
+      expect(inLoop!.suggestion).toContain('Hoist');
+    });
+
+    it('emits no findings when each input is queried once', () => {
+      const report = analyzeBalanceQueries(DIFFERENT_ACCOUNTS);
+
+      expect(report.queries).toHaveLength(2);
+      expect(report.findings).toHaveLength(0);
+    });
+
+    it('keeps reads in different functions apart', () => {
+      const source = `
+        pub fn one(env: Env, token: Address, user: Address) {
+            let client = token::Client::new(&env, &token);
+            let a = client.balance(&user);
+        }
+        pub fn two(env: Env, token: Address, user: Address) {
+            let client = token::Client::new(&env, &token);
+            let b = client.balance(&user);
+        }
+      `;
+      const report = analyzeBalanceQueries(source);
+
+      expect(report.groups).toHaveLength(2);
+      expect(report.findings).toHaveLength(0);
+    });
+
+    it('generates findings from pre-computed queries and groups', () => {
+      const queries = extractBalanceQueries(REPEATED_QUERIES);
+      const findings = generateBalanceFindings(
+        queries,
+        groupBalanceQueries(REPEATED_QUERIES, queries),
+      );
+
+      expect(findings).toHaveLength(1);
+      expect(findings[0].account).toBe('user');
+    });
+  });
+
+  describe('report metrics', () => {
+    it('counts total, redundant and reusable queries', () => {
+      const report = analyzeBalanceQueries(REPEATED_QUERIES);
+
+      expect(report.metrics).toMatchObject({
+        totalQueries: 3,
+        uniqueInputs: 1,
+        redundantQueries: 2,
+        reusableQueries: 2,
+      });
+    });
+
+    it('does not count non-reusable repeats as reusable', () => {
+      const report = analyzeBalanceQueries(MUTATED_BETWEEN);
+
+      expect(report.metrics.redundantQueries).toBe(1);
+      expect(report.metrics.reusableQueries).toBe(0);
+    });
+
+    it('handles empty source without throwing', () => {
+      const report = analyzeBalanceQueries('');
+
+      expect(report.queries).toHaveLength(0);
+      expect(report.findings).toHaveLength(0);
+    });
+  });
+});

--- a/packages/analyzers/soroban/calls/balance-query-analyzer.ts
+++ b/packages/analyzers/soroban/calls/balance-query-analyzer.ts
@@ -1,0 +1,344 @@
+/**
+ * Soroban Balance Query Analyzer
+ *
+ * Detects repeated token balance reads along a single transaction path. Each
+ * `balance()` read is a contract call (or a storage read) that costs CPU and
+ * ledger-read budget, so re-reading an unchanged balance is pure overhead.
+ *
+ * A repeat is only reported as safely reusable when nothing between the two
+ * reads can have changed the balance: no transfer/mint/burn on that token, no
+ * storage write, and no opaque cross-contract call. Otherwise the repeat is
+ * reported at `info` severity with the mutation that forces the re-read, so the
+ * suggestion never trades correctness for budget.
+ */
+
+import {
+  BlockFrame,
+  blockStackAt,
+  createLineResolver,
+  extractArgs,
+  extractFunctions,
+  isInLoop,
+  maskNonCode,
+  normalizeExpr,
+  onExclusiveBranches,
+  receiverBefore,
+  resolveTokenBindings,
+  resolveTokenFromReceiver,
+  splitArgs,
+} from '../common/source-utils';
+
+export type Severity = 'high' | 'medium' | 'low' | 'info';
+
+/** Method-style balance reads: `client.balance(&addr)`. */
+const BALANCE_METHODS = ['balance', 'balance_of', 'spendable_balance'];
+
+/** Free-function balance reads: `read_balance(&env, &addr)`. */
+const BALANCE_FUNCTIONS = ['read_balance', 'get_balance', 'load_balance'];
+
+/**
+ * Operations that can change a balance. Anything matching between two reads
+ * invalidates reuse of the first result.
+ */
+const MUTATION_PATTERNS: Array<{ label: string; pattern: RegExp }> = [
+  { label: 'token transfer', pattern: /\.\s*transfer(_from)?\s*\(/ },
+  { label: 'token mint', pattern: /\.\s*mint\s*\(/ },
+  { label: 'token burn', pattern: /\.\s*burn(_from)?\s*\(/ },
+  { label: 'token clawback', pattern: /\.\s*clawback\s*\(/ },
+  { label: 'balance write', pattern: /\b(write_balance|set_balance|receive_balance|spend_balance)\s*\(/ },
+  { label: 'storage write', pattern: /\.\s*storage\s*\(\s*\)[\s\S]{0,80}?\.\s*(set|update|remove|extend_ttl)\s*\(/ },
+  { label: 'cross-contract call', pattern: /\b(invoke_contract|try_invoke_contract)\s*[:(<]/ },
+];
+
+export interface BalanceQuery {
+  /** Enclosing function name. */
+  fn: string;
+  /** Token/asset the balance is read from. */
+  asset: string;
+  /** Account whose balance is read. */
+  account: string;
+  /** The method or function used for the read. */
+  method: string;
+  line: number;
+  /** Character offset of the call site. */
+  offset: number;
+  stack: BlockFrame[];
+  inLoop: boolean;
+}
+
+/** A set of balance reads sharing the same (function, asset, account) inputs. */
+export interface BalanceQueryGroup {
+  fn: string;
+  asset: string;
+  account: string;
+  count: number;
+  lines: number[];
+  /** True when every repeat in the group can reuse the first result. */
+  safeToReuse: boolean;
+  /** The mutation (if any) that forces a re-read. */
+  invalidatedBy?: string;
+  /** Line of the mutation that forces a re-read. */
+  invalidatedAtLine?: number;
+}
+
+export interface BalanceQueryFinding {
+  ruleId: 'soroban-redundant-balance-query' | 'soroban-balance-query-in-loop';
+  severity: Severity;
+  line: number;
+  relatedLines: number[];
+  fn: string;
+  asset: string;
+  account: string;
+  message: string;
+  suggestion: string;
+  /** True when the repeated read may be replaced by a cached value. */
+  safeToReuse: boolean;
+}
+
+export interface BalanceQueryReport {
+  queries: BalanceQuery[];
+  groups: BalanceQueryGroup[];
+  findings: BalanceQueryFinding[];
+  metrics: {
+    totalQueries: number;
+    uniqueInputs: number;
+    redundantQueries: number;
+    reusableQueries: number;
+  };
+}
+
+/**
+ * Extract every balance read from Soroban Rust source, resolving the asset each
+ * read targets and the account it is keyed on.
+ */
+export function extractBalanceQueries(source: string): BalanceQuery[] {
+  const masked = maskNonCode(source);
+  const lineOf = createLineResolver(source);
+  const bindings = resolveTokenBindings(masked, source);
+  const functions = extractFunctions(masked, source);
+  const queries: BalanceQuery[] = [];
+
+  const methodRe = new RegExp(`\\.\\s*(${BALANCE_METHODS.join('|')})\\s*\\(`, 'g');
+  const fnRe = new RegExp(`(?<![.\\w])(${BALANCE_FUNCTIONS.join('|')})\\s*\\(`, 'g');
+
+  const record = (
+    index: number,
+    method: string,
+    openParen: number,
+    asset: string,
+  ): void => {
+    const enclosing = functions.find((f) => index >= f.bodyStart && index < f.bodyEnd);
+    if (!enclosing) return;
+
+    const args = splitArgs(extractArgs(masked, source, openParen).text);
+    // The account is the last argument; `&env` leads the free-function form.
+    const account = args.length > 0 ? normalizeExpr(args[args.length - 1]) : 'unknown';
+    const stack = blockStackAt(masked, enclosing.bodyStart, index);
+
+    queries.push({
+      fn: enclosing.name,
+      asset,
+      account,
+      method,
+      line: lineOf(index),
+      offset: index,
+      stack,
+      inLoop: isInLoop(stack),
+    });
+  };
+
+  let m: RegExpExecArray | null;
+  while ((m = methodRe.exec(masked)) !== null) {
+    const receiver = receiverBefore(source, m.index);
+    record(m.index, m[1], m.index + m[0].length - 1, resolveTokenFromReceiver(receiver, bindings));
+  }
+
+  while ((m = fnRe.exec(masked)) !== null) {
+    // Skip the declaration of the helper itself.
+    if (/\bfn\s+$/.test(masked.slice(Math.max(0, m.index - 8), m.index))) continue;
+    record(m.index, m[1], m.index + m[0].length - 1, 'self');
+  }
+
+  return queries.sort((a, b) => a.offset - b.offset);
+}
+
+/**
+ * Find the first balance-mutating operation between two offsets, if any.
+ */
+function findMutationBetween(
+  source: string,
+  masked: string,
+  start: number,
+  end: number,
+): { label: string; line: number } | undefined {
+  const segment = masked.slice(start, end);
+  const lineOf = createLineResolver(source);
+
+  let best: { label: string; line: number; offset: number } | undefined;
+  for (const { label, pattern } of MUTATION_PATTERNS) {
+    const match = segment.match(pattern);
+    if (match?.index === undefined) continue;
+    const offset = start + match.index;
+    if (!best || offset < best.offset) {
+      best = { label, line: lineOf(offset), offset };
+    }
+  }
+
+  return best ? { label: best.label, line: best.line } : undefined;
+}
+
+/**
+ * Group balance reads by their (function, asset, account) inputs and decide,
+ * per group, whether the repeats may reuse the first result.
+ */
+export function groupBalanceQueries(
+  source: string,
+  queries: BalanceQuery[],
+): BalanceQueryGroup[] {
+  const masked = maskNonCode(source);
+  const buckets = new Map<string, BalanceQuery[]>();
+
+  for (const q of queries) {
+    const key = `${q.fn}|${q.asset}|${q.account}`;
+    const list = buckets.get(key) ?? [];
+    list.push(q);
+    buckets.set(key, list);
+  }
+
+  const groups: BalanceQueryGroup[] = [];
+
+  for (const list of buckets.values()) {
+    const [first] = list;
+    let safeToReuse = list.length > 1;
+    let invalidatedBy: string | undefined;
+    let invalidatedAtLine: number | undefined;
+
+    for (let i = 1; i < list.length && safeToReuse; i++) {
+      const prev = list[i - 1];
+      const current = list[i];
+
+      const mutation = findMutationBetween(source, masked, prev.offset, current.offset);
+      if (mutation) {
+        safeToReuse = false;
+        invalidatedBy = mutation.label;
+        invalidatedAtLine = mutation.line;
+        break;
+      }
+
+      if (onExclusiveBranches(prev.stack, current.stack)) {
+        safeToReuse = false;
+        invalidatedBy = 'conditional branch — the reads are on different paths';
+        invalidatedAtLine = current.line;
+      }
+    }
+
+    groups.push({
+      fn: first.fn,
+      asset: first.asset,
+      account: first.account,
+      count: list.length,
+      lines: list.map((q) => q.line),
+      safeToReuse,
+      invalidatedBy,
+      invalidatedAtLine,
+    });
+  }
+
+  return groups.sort((a, b) => b.count - a.count);
+}
+
+/**
+ * Turn grouped queries into optimization findings.
+ */
+export function generateBalanceFindings(
+  queries: BalanceQuery[],
+  groups: BalanceQueryGroup[],
+): BalanceQueryFinding[] {
+  const findings: BalanceQueryFinding[] = [];
+
+  for (const group of groups) {
+    if (group.count < 2) continue;
+
+    const [line, ...relatedLines] = group.lines;
+    const severity: Severity = !group.safeToReuse
+      ? 'info'
+      : group.count >= 4
+        ? 'high'
+        : group.count >= 3
+          ? 'medium'
+          : 'low';
+
+    findings.push({
+      ruleId: 'soroban-redundant-balance-query',
+      severity,
+      line,
+      relatedLines,
+      fn: group.fn,
+      asset: group.asset,
+      account: group.account,
+      message:
+        `Balance of '${group.account}' on asset '${group.asset}' is queried ${group.count} times ` +
+        `in '${group.fn}' (lines: ${group.lines.join(', ')}).`,
+      suggestion: group.safeToReuse
+        ? `Read the balance once into a local variable and reuse it — nothing between lines ${group.lines[0]} and ${group.lines[group.lines.length - 1]} can change it, saving ${group.count - 1} read(s).`
+        : `Keep the re-read: a ${group.invalidatedBy} at line ${group.invalidatedAtLine} may change this balance. Reuse only the reads that precede it.`,
+      safeToReuse: group.safeToReuse,
+    });
+  }
+
+  // A balance read inside a loop with loop-invariant inputs repeats per iteration.
+  const loopSeen = new Set<string>();
+  for (const q of queries) {
+    if (!q.inLoop) continue;
+    const key = `${q.fn}|${q.asset}|${q.account}`;
+    if (loopSeen.has(key)) continue;
+    loopSeen.add(key);
+
+    findings.push({
+      ruleId: 'soroban-balance-query-in-loop',
+      severity: 'high',
+      line: q.line,
+      relatedLines: [],
+      fn: q.fn,
+      asset: q.asset,
+      account: q.account,
+      message: `Balance of '${q.account}' on asset '${q.asset}' is queried inside a loop in '${q.fn}'.`,
+      suggestion:
+        'Hoist the balance read above the loop if the account and asset do not vary per iteration; ' +
+        'otherwise track the running balance locally instead of re-reading it.',
+      safeToReuse: true,
+    });
+  }
+
+  return findings.sort((a, b) => a.line - b.line);
+}
+
+/**
+ * Full analysis entry point.
+ */
+export function analyzeBalanceQueries(source: string): BalanceQueryReport {
+  const queries = extractBalanceQueries(source);
+  const groups = groupBalanceQueries(source, queries);
+  const findings = generateBalanceFindings(queries, groups);
+
+  const redundantQueries = groups.reduce(
+    (sum, g) => sum + (g.count > 1 ? g.count - 1 : 0),
+    0,
+  );
+  const reusableQueries = groups.reduce(
+    (sum, g) => sum + (g.safeToReuse && g.count > 1 ? g.count - 1 : 0),
+    0,
+  );
+
+  return {
+    queries,
+    groups,
+    findings,
+    metrics: {
+      totalQueries: queries.length,
+      uniqueInputs: groups.length,
+      redundantQueries,
+      reusableQueries,
+    },
+  };
+}

--- a/packages/analyzers/soroban/common/source-utils.ts
+++ b/packages/analyzers/soroban/common/source-utils.ts
@@ -1,0 +1,385 @@
+/**
+ * Shared lexical helpers for the Soroban (Rust) source analyzers.
+ *
+ * These analyzers are lexical rather than AST-based, so the helpers here exist
+ * to make the regex scanning safe: comments and string literals are masked out,
+ * offsets map back to line numbers, and call arguments are extracted with
+ * balanced-paren matching so multi-line call sites parse correctly.
+ */
+
+/** Kind of block a call site is nested inside. */
+export type BlockKind = 'fn' | 'if' | 'else' | 'match' | 'loop' | 'block';
+
+/** One enclosing block, identified by kind and the offset of its `{`. */
+export interface BlockFrame {
+  kind: BlockKind;
+  /** Offset of the opening brace — distinguishes sibling blocks of one kind. */
+  start: number;
+}
+
+export interface FunctionBlock {
+  name: string;
+  /** Offset of the `{` opening the body. */
+  bodyStart: number;
+  /** Offset just past the `}` closing the body. */
+  bodyEnd: number;
+  /** 1-based line of the `fn` keyword. */
+  line: number;
+}
+
+/**
+ * Replace the contents of comments and string/char literals with spaces.
+ *
+ * Offsets and line breaks are preserved, so the masked copy can be scanned with
+ * regexes while indices still address the original source.
+ */
+export function maskNonCode(source: string): string {
+  const out = source.split('');
+  let i = 0;
+
+  const blank = (from: number, to: number) => {
+    for (let k = from; k < to && k < out.length; k++) {
+      if (out[k] !== '\n') out[k] = ' ';
+    }
+  };
+
+  while (i < source.length) {
+    const two = source.slice(i, i + 2);
+
+    if (two === '//') {
+      let end = source.indexOf('\n', i);
+      if (end === -1) end = source.length;
+      blank(i, end);
+      i = end;
+      continue;
+    }
+
+    if (two === '/*') {
+      let depth = 1;
+      let k = i + 2;
+      while (k < source.length && depth > 0) {
+        if (source.slice(k, k + 2) === '/*') {
+          depth++;
+          k += 2;
+        } else if (source.slice(k, k + 2) === '*/') {
+          depth--;
+          k += 2;
+        } else {
+          k++;
+        }
+      }
+      blank(i, k);
+      i = k;
+      continue;
+    }
+
+    if (source[i] === '"') {
+      let k = i + 1;
+      while (k < source.length) {
+        if (source[k] === '\\') {
+          k += 2;
+          continue;
+        }
+        if (source[k] === '"') {
+          k++;
+          break;
+        }
+        k++;
+      }
+      blank(i, k);
+      i = k;
+      continue;
+    }
+
+    // Char literal — must not swallow Rust lifetimes such as `&'a str`.
+    if (source[i] === "'" && /^'(?:\\.|[^\\'])'/.test(source.slice(i, i + 4))) {
+      const end = source.indexOf("'", source[i + 1] === '\\' ? i + 3 : i + 2) + 1;
+      blank(i, end);
+      i = end;
+      continue;
+    }
+
+    i++;
+  }
+
+  return out.join('');
+}
+
+/** Builds an offset → 1-based line resolver for a source string. */
+export function createLineResolver(source: string): (offset: number) => number {
+  const starts: number[] = [0];
+  for (let i = 0; i < source.length; i++) {
+    if (source[i] === '\n') starts.push(i + 1);
+  }
+
+  return (offset: number): number => {
+    let lo = 0;
+    let hi = starts.length - 1;
+    while (lo < hi) {
+      const mid = (lo + hi + 1) >> 1;
+      if (starts[mid] <= offset) lo = mid;
+      else hi = mid - 1;
+    }
+    return lo + 1;
+  };
+}
+
+/**
+ * Extract function bodies via brace counting on masked source.
+ */
+export function extractFunctions(masked: string, original: string): FunctionBlock[] {
+  const blocks: FunctionBlock[] = [];
+  const lineOf = createLineResolver(original);
+  const fnRe = /\bfn\s+([A-Za-z_][A-Za-z0-9_]*)/g;
+
+  let m: RegExpExecArray | null;
+  while ((m = fnRe.exec(masked)) !== null) {
+    const braceStart = findBodyStart(masked, m.index + m[0].length);
+    if (braceStart === -1) continue;
+
+    const bodyEnd = matchBrace(masked, braceStart);
+    if (bodyEnd === -1) continue;
+
+    blocks.push({
+      name: m[1],
+      bodyStart: braceStart,
+      bodyEnd,
+      line: lineOf(m.index),
+    });
+  }
+
+  return blocks;
+}
+
+/** Finds the `{` that opens a function body, skipping the signature. */
+function findBodyStart(masked: string, from: number): number {
+  let depth = 0;
+  for (let i = from; i < masked.length; i++) {
+    const ch = masked[i];
+    if (ch === '(' || ch === '[') depth++;
+    else if (ch === ')' || ch === ']') depth--;
+    else if (ch === ';' && depth === 0) return -1; // trait method, no body
+    else if (ch === '{' && depth === 0) return i;
+  }
+  return -1;
+}
+
+/** Returns the offset just past the `}` matching the `{` at `open`. */
+export function matchBrace(masked: string, open: number): number {
+  let depth = 0;
+  for (let i = open; i < masked.length; i++) {
+    if (masked[i] === '{') depth++;
+    else if (masked[i] === '}') {
+      depth--;
+      if (depth === 0) return i + 1;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Extract the raw text between the `(` at `openParen` and its matching `)`.
+ * Reads from `original` so argument text keeps string literals intact, but uses
+ * `masked` to find the boundary so parens inside literals are ignored.
+ */
+export function extractArgs(
+  masked: string,
+  original: string,
+  openParen: number,
+): { text: string; end: number } {
+  let depth = 0;
+  for (let i = openParen; i < masked.length; i++) {
+    const ch = masked[i];
+    if (ch === '(') depth++;
+    else if (ch === ')') {
+      depth--;
+      if (depth === 0) {
+        return { text: original.slice(openParen + 1, i), end: i + 1 };
+      }
+    }
+  }
+  return { text: original.slice(openParen + 1), end: masked.length };
+}
+
+/** Split an argument list on top-level commas. */
+export function splitArgs(args: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = '';
+
+  for (const ch of args) {
+    if (ch === '(' || ch === '[' || ch === '<' || ch === '{') depth++;
+    else if (ch === ')' || ch === ']' || ch === '>' || ch === '}') depth--;
+
+    if (ch === ',' && depth === 0) {
+      parts.push(current);
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+
+  if (current.trim().length > 0) parts.push(current);
+  return parts.map(normalizeExpr).filter((p) => p.length > 0);
+}
+
+/**
+ * Normalize an expression so that syntactic noise does not defeat equality
+ * checks: `&to.clone()`, `to.clone()` and `&to` all fingerprint as `to`.
+ */
+export function normalizeExpr(expr: string): string {
+  return expr
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^[&*]+\s*/, '')
+    .replace(/(?:\.clone\(\))+$/, '')
+    .replace(/\.into\(\)$/, '')
+    .replace(/\.to_owned\(\)$/, '')
+    .trim();
+}
+
+/**
+ * Walk backwards from a `.method(` call to capture its receiver expression.
+ */
+export function receiverBefore(original: string, dotIndex: number): string {
+  let depth = 0;
+  let i = dotIndex - 1;
+
+  while (i >= 0) {
+    const ch = original[i];
+    if (ch === ')' || ch === ']' || ch === '>') depth++;
+    else if (ch === '(' || ch === '[' || ch === '<') {
+      if (depth === 0) break;
+      depth--;
+    } else if (depth === 0 && !/[A-Za-z0-9_.:&\s]/.test(ch)) {
+      break;
+    }
+    i--;
+  }
+
+  return original.slice(i + 1, dotIndex).trim();
+}
+
+/**
+ * Resolve `let <name> = token::Client::new(&env, &<token>)` bindings so a later
+ * `<name>.transfer(..)` can be attributed to the token it was built from.
+ *
+ * Returns a map of binding name → normalized token expression.
+ */
+export function resolveTokenBindings(masked: string, original: string): Map<string, string> {
+  const bindings = new Map<string, string>();
+  const re = /\blet\s+(?:mut\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*(?::[^=;]+)?=\s*([A-Za-z_][A-Za-z0-9_:]*)\s*::\s*new\s*\(/g;
+
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(masked)) !== null) {
+    const ctor = m[2];
+    if (!/client$/i.test(ctor.split('::').pop() ?? '') && !/token/i.test(ctor)) continue;
+
+    const openParen = m.index + m[0].length - 1;
+    const args = splitArgs(extractArgs(masked, original, openParen).text);
+    // Convention: Client::new(&env, &token_address)
+    const token = args.length >= 2 ? args[1] : args[0] ?? 'unknown';
+    bindings.set(m[1], token);
+  }
+
+  return bindings;
+}
+
+/**
+ * Resolve the token address a call receiver refers to.
+ *
+ * Handles both `client.transfer(..)` (via `bindings`) and the inline
+ * `token::Client::new(&env, &usdc).transfer(..)` form.
+ */
+export function resolveTokenFromReceiver(
+  receiver: string,
+  bindings: Map<string, string>,
+): string {
+  const inline = receiver.match(/::\s*new\s*\(([^)]*)\)\s*$/);
+  if (inline) {
+    const args = splitArgs(inline[1]);
+    return args.length >= 2 ? args[1] : args[0] ?? 'unknown';
+  }
+
+  const base = normalizeExpr(receiver).split('.')[0];
+  return bindings.get(base) ?? (base.length > 0 ? base : 'unknown');
+}
+
+/**
+ * Compute the stack of enclosing blocks for an offset inside a function body.
+ * Each frame carries the offset of its opening brace so that two call sites in
+ * *different* `if` blocks are distinguishable from two sites in the same one.
+ */
+export function blockStackAt(
+  masked: string,
+  bodyStart: number,
+  offset: number,
+): BlockFrame[] {
+  const stack: BlockFrame[] = [{ kind: 'fn', start: bodyStart }];
+
+  for (let i = bodyStart + 1; i < offset && i < masked.length; i++) {
+    const ch = masked[i];
+    if (ch === '{') {
+      stack.push({
+        kind: classifyBlock(masked.slice(Math.max(bodyStart, i - 160), i)),
+        start: i,
+      });
+    } else if (ch === '}') {
+      if (stack.length > 1) stack.pop();
+    }
+  }
+
+  return stack;
+}
+
+function classifyBlock(preceding: string): BlockKind {
+  if (/=>\s*$/.test(preceding)) return 'match';
+  const m = preceding.match(/\b(if|else|for|while|loop|match)\b[^{};]*$/);
+  if (!m) return 'block';
+  switch (m[1]) {
+    case 'if':
+      return 'if';
+    case 'else':
+      return 'else';
+    case 'match':
+      return 'match';
+    default:
+      return 'loop';
+  }
+}
+
+const BRANCH_KINDS: ReadonlySet<BlockKind> = new Set<BlockKind>(['if', 'else', 'match']);
+
+/** True when the call site sits inside a loop body. */
+export function isInLoop(stack: BlockFrame[]): boolean {
+  return stack.some((f) => f.kind === 'loop');
+}
+
+/** True when the call site sits inside a conditional branch or match arm. */
+export function isInBranch(stack: BlockFrame[]): boolean {
+  return stack.some((f) => BRANCH_KINDS.has(f.kind));
+}
+
+/**
+ * True when two call sites cannot be assumed to both execute, in order, on
+ * every run — they live in different branches, or one is guarded by a
+ * conditional the other is not. Consolidating across such sites is unsafe.
+ */
+export function onExclusiveBranches(a: BlockFrame[], b: BlockFrame[]): boolean {
+  const len = Math.min(a.length, b.length);
+
+  for (let i = 0; i < len; i++) {
+    if (a[i].start !== b[i].start) {
+      // Diverged: exclusive if either path enters a branch at or below here.
+      return (
+        a.slice(i).some((f) => BRANCH_KINDS.has(f.kind)) ||
+        b.slice(i).some((f) => BRANCH_KINDS.has(f.kind))
+      );
+    }
+  }
+
+  // One stack is a prefix of the other: the deeper site is conditionally
+  // executed if any of its extra frames is a branch.
+  const deeper = a.length >= b.length ? a : b;
+  return deeper.slice(len).some((f) => BRANCH_KINDS.has(f.kind));
+}

--- a/packages/rules/soroban/src/index.ts
+++ b/packages/rules/soroban/src/index.ts
@@ -12,3 +12,4 @@ export * from './budget';
 export * from './prioritization';
 export * from './functions';
 export * from './resources';
+export * from './tokens';

--- a/packages/rules/soroban/src/tokens/index.ts
+++ b/packages/rules/soroban/src/tokens/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Soroban token rules: unnecessary transfers and redundant balance queries.
+ */
+export {
+  detectUnnecessaryTransfers,
+  detectConsolidatableTransfers,
+  analyzeTransferGraph,
+} from './unnecessary-transfers-rule';
+export type {
+  TokenTransferFinding,
+  TokenTransferReport,
+  TransferEdge,
+  TransferPath,
+  TransferSite,
+} from './unnecessary-transfers-rule';
+
+export {
+  detectRedundantBalanceQueries,
+  detectReusableBalanceQueries,
+  analyzeBalanceQueryUsage,
+} from './redundant-balance-queries-rule';
+export type {
+  BalanceQuery,
+  BalanceQueryFinding,
+  BalanceQueryGroup,
+  BalanceQueryReport,
+} from './redundant-balance-queries-rule';

--- a/packages/rules/soroban/src/tokens/redundant-balance-queries-rule.ts
+++ b/packages/rules/soroban/src/tokens/redundant-balance-queries-rule.ts
@@ -1,0 +1,36 @@
+/**
+ * Rule: soroban-redundant-balance-query
+ *
+ * Surfaces repeated token balance reads along a transaction path, separating
+ * repeats whose result can safely be reused from repeats forced by an
+ * intervening balance mutation.
+ */
+import {
+  analyzeBalanceQueries,
+  BalanceQuery,
+  BalanceQueryFinding,
+  BalanceQueryGroup,
+  BalanceQueryReport,
+} from '../../../../analyzers/soroban/calls/balance-query-analyzer';
+
+export type {
+  BalanceQuery,
+  BalanceQueryFinding,
+  BalanceQueryGroup,
+  BalanceQueryReport,
+};
+
+/** All redundant-balance-query findings, including non-reusable repeats. */
+export function detectRedundantBalanceQueries(source: string): BalanceQueryFinding[] {
+  return analyzeBalanceQueries(source).findings;
+}
+
+/** Only the repeats whose result can safely be cached and reused. */
+export function detectReusableBalanceQueries(source: string): BalanceQueryFinding[] {
+  return analyzeBalanceQueries(source).findings.filter((f) => f.safeToReuse);
+}
+
+/** Full report: query sites, grouped inputs and findings. */
+export function analyzeBalanceQueryUsage(source: string): BalanceQueryReport {
+  return analyzeBalanceQueries(source);
+}

--- a/packages/rules/soroban/src/tokens/unnecessary-transfers-rule.ts
+++ b/packages/rules/soroban/src/tokens/unnecessary-transfers-rule.ts
@@ -1,0 +1,41 @@
+/**
+ * Rule: soroban-unnecessary-token-transfer
+ *
+ * Surfaces token transfers that can be avoided or consolidated. Findings marked
+ * `preserved` are security-sensitive — they are reported for visibility but no
+ * consolidation is proposed.
+ */
+import {
+  analyzeTokenTransfers,
+  TokenTransferFinding,
+  TokenTransferReport,
+  TransferEdge,
+  TransferPath,
+  TransferSite,
+} from '../../../../analyzers/soroban/callgraph/token-transfer-analyzer';
+
+export type {
+  TokenTransferFinding,
+  TokenTransferReport,
+  TransferEdge,
+  TransferPath,
+  TransferSite,
+};
+
+/** All unnecessary-transfer findings, including preserved ones. */
+export function detectUnnecessaryTransfers(source: string): TokenTransferFinding[] {
+  return analyzeTokenTransfers(source).findings;
+}
+
+/**
+ * Only the findings that are safe to act on — transfers guarded by auth checks,
+ * branches or loops are filtered out.
+ */
+export function detectConsolidatableTransfers(source: string): TokenTransferFinding[] {
+  return analyzeTokenTransfers(source).findings.filter((f) => !f.preserved);
+}
+
+/** Full transfer-graph report: sites, edges, multi-hop paths and findings. */
+export function analyzeTransferGraph(source: string): TokenTransferReport {
+  return analyzeTokenTransfers(source);
+}

--- a/packages/rules/soroban/tests/token-rules.spec.ts
+++ b/packages/rules/soroban/tests/token-rules.spec.ts
@@ -1,0 +1,115 @@
+import {
+  analyzeBalanceQueryUsage,
+  analyzeTransferGraph,
+  detectConsolidatableTransfers,
+  detectRedundantBalanceQueries,
+  detectReusableBalanceQueries,
+  detectUnnecessaryTransfers,
+} from '../src/tokens';
+
+const FEE_SPLITTER = `
+pub fn collect_fees(env: Env, token: Address, user: Address, treasury: Address) {
+    let client = token::Client::new(&env, &token);
+    client.transfer(&user, &treasury, &protocol_fee);
+    client.transfer(&user, &treasury, &relayer_fee);
+}
+`;
+
+const AUTH_GUARDED = `
+pub fn withdraw(env: Env, token: Address, user: Address, treasury: Address) {
+    let client = token::Client::new(&env, &token);
+    client.transfer(&user, &treasury, &first);
+    user.require_auth();
+    client.transfer(&user, &treasury, &second);
+}
+`;
+
+const REPEATED_BALANCE_READS = `
+pub fn quote(env: Env, token: Address, user: Address) -> i128 {
+    let client = token::Client::new(&env, &token);
+    let a = client.balance(&user);
+    let b = client.balance(&user);
+    a + b
+}
+`;
+
+const BALANCE_AFTER_TRANSFER = `
+pub fn settle(env: Env, token: Address, user: Address, treasury: Address) {
+    let client = token::Client::new(&env, &token);
+    let before = client.balance(&user);
+    client.transfer(&user, &treasury, &fee);
+    let after = client.balance(&user);
+}
+`;
+
+describe('soroban token rules', () => {
+  describe('soroban-unnecessary-token-transfer', () => {
+    it('reports redundant transfers on the same edge', () => {
+      const findings = detectUnnecessaryTransfers(FEE_SPLITTER);
+
+      expect(findings).toHaveLength(1);
+      expect(findings[0].ruleId).toBe('soroban-redundant-token-transfer');
+      expect(findings[0].fn).toBe('collect_fees');
+      expect(findings[0].token).toBe('token');
+    });
+
+    it('excludes security-sensitive transfers from consolidation candidates', () => {
+      expect(detectUnnecessaryTransfers(AUTH_GUARDED)).toHaveLength(1);
+      expect(detectConsolidatableTransfers(AUTH_GUARDED)).toHaveLength(0);
+    });
+
+    it('exposes the transfer graph alongside the findings', () => {
+      const report = analyzeTransferGraph(FEE_SPLITTER);
+
+      expect(report.transfers).toHaveLength(2);
+      expect(report.edges).toHaveLength(1);
+      expect(report.metrics.redundantTransfers).toBe(1);
+    });
+
+    it('returns no findings for a contract with a single transfer', () => {
+      const findings = detectUnnecessaryTransfers(`
+        pub fn pay(env: Env, token: Address, user: Address, treasury: Address) {
+            let client = token::Client::new(&env, &token);
+            client.transfer(&user, &treasury, &amount);
+        }
+      `);
+
+      expect(findings).toHaveLength(0);
+    });
+  });
+
+  describe('soroban-redundant-balance-query', () => {
+    it('reports repeated balance reads with identical inputs', () => {
+      const findings = detectRedundantBalanceQueries(REPEATED_BALANCE_READS);
+
+      expect(findings).toHaveLength(1);
+      expect(findings[0].ruleId).toBe('soroban-redundant-balance-query');
+      expect(findings[0].account).toBe('user');
+      expect(findings[0].safeToReuse).toBe(true);
+    });
+
+    it('excludes reads invalidated by an intervening transfer from reuse candidates', () => {
+      expect(detectRedundantBalanceQueries(BALANCE_AFTER_TRANSFER)).toHaveLength(1);
+      expect(detectReusableBalanceQueries(BALANCE_AFTER_TRANSFER)).toHaveLength(0);
+    });
+
+    it('exposes grouped query inputs alongside the findings', () => {
+      const report = analyzeBalanceQueryUsage(REPEATED_BALANCE_READS);
+
+      expect(report.queries).toHaveLength(2);
+      expect(report.groups).toHaveLength(1);
+      expect(report.metrics.reusableQueries).toBe(1);
+    });
+
+    it('returns no findings when each balance is read once', () => {
+      const findings = detectRedundantBalanceQueries(`
+        pub fn check(env: Env, token: Address, user: Address) {
+            let client = token::Client::new(&env, &token);
+            let a = client.balance(&user);
+        }
+      `);
+
+      expect(findings).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## feat(soroban): detect unnecessary token transfers and redundant balance queries

Implements two Soroban token-optimization analyzers and the rule wrappers that
expose them through the `@rules/soroban` package.

Closes #868 
Closes #865 
Closes #866 
Closes #867 

---

## Motivation

Soroban charges for every contract call and every ledger read. Two patterns show
up repeatedly in real token contracts and both are pure overhead:

1. **Fan-out transfers** — a fee splitter that issues three separate
   `transfer` calls to the same treasury pays three full contract-call costs for
   what is arithmetically one transfer. Relay patterns (`user → escrow → merchant`)
   pay double when the intermediate never needs custody.
2. **Re-read balances** — `client.balance(&user)` called three times in one
   function burns three ledger reads to produce the same value.

Neither is safe to collapse unconditionally, which is the hard part: an auth
check between two transfers, or a `mint` between two balance reads, makes the
repetition load-bearing. Both analyzers therefore report the repetition *and*
the reason it may not be collapsible, rather than emitting a blind "merge these"
suggestion a contributor could act on and break the contract.

---

## What's included

### 1. Token transfer analyzer

`packages/analyzers/soroban/callgraph/token-transfer-analyzer.ts`

Extracts every transfer call site, resolves the token each one targets, builds a
per-function directed transfer graph, and traces multi-hop relay paths.

**Token resolution** handles both idioms:

```rust
let client = token::Client::new(&env, &token);   // binding tracked
client.transfer(&user, &treasury, &amount);      // → token = `token`

token::Client::new(&env, &usdc).transfer(..);    // inline form → token = `usdc`
```

`transfer` and `transfer_from` are both understood, with their differing
argument slots (`transfer_from` puts the real `from` in position 1, not 0).

**Findings emitted:**

| Rule ID | Detects |
|---|---|
| `soroban-redundant-token-transfer` | ≥2 transfers on the same `(token, from → to)` edge in one function |
| `soroban-intermediate-token-transfer` | Relay chain `A → B → C` on one token, collapsible to a direct `A → C` |
| `soroban-self-token-transfer` | `from == to` — changes no balance, still pays full call cost |
| `soroban-zero-token-transfer` | Hard-coded `0` / `0i128` amount |

**Security-sensitive preservation.** A finding carries `preserved: true`,
severity `info`, and a `preservedReason` — and *never* proposes consolidation —
when any of these hold:

- an authorization or assertion sits between the two sites
  (`require_auth`, `require_auth_for_args`, `authorize_as_current_contract`,
  `check_auth`, `panic_with_error`, `assert!`, `assert_eq!`, `require!`)
- the sites are on mutually exclusive control-flow paths (different `if`/`else`
  blocks or `match` arms), so they may not both execute
- either site is inside a loop, so the transfer count is data-dependent
- (relays only) the two hops move *different* amounts, meaning the intermediate
  balance is load-bearing and cannot be bypassed

```rust
// preserved — the auth check may depend on the first transfer having settled
client.transfer(&user, &treasury, &first);
user.require_auth();
client.transfer(&user, &treasury, &second);

// preserved — only one of these ever runs
if is_premium { client.transfer(&user, &treasury, &premium_fee); }
else          { client.transfer(&user, &treasury, &standard_fee); }
```

### 2. Balance query analyzer

`packages/analyzers/soroban/calls/balance-query-analyzer.ts`

Extracts balance reads, groups them by their inputs, and decides per group
whether the repeat can reuse the first result.

**Read forms recognised:** the method style `balance`, `balance_of`,
`spendable_balance`, and the free-function style `read_balance`, `get_balance`,
`load_balance` (where the account is the trailing argument after `&env`).

**Input comparison.** Reads group on `(function, asset, account)`, so only
genuinely identical inputs are ever compared. Different accounts, different
assets, and different enclosing functions all stay in separate groups. Borrow
and clone noise is normalized away, so `&user`, `user.clone()` and `user`
fingerprint identically and a real duplicate isn't missed on syntax alone.

**Safe reuse.** A repeat is reported as reusable *only* when nothing between the
two reads can move the balance. Any of these invalidates it, and the finding
names which one and at what line:

`token transfer` · `token mint` · `token burn` · `token clawback` ·
`balance write` (`write_balance`/`set_balance`/`receive_balance`/`spend_balance`) ·
`storage write` (`.set`/`.update`/`.remove`/`.extend_ttl`) ·
`cross-contract call` (`invoke_contract`/`try_invoke_contract`) ·
divergent conditional branches

| Rule ID | Detects |
|---|---|
| `soroban-redundant-balance-query` | ≥2 reads on identical inputs; `low`/`medium`/`high` by count when reusable, `info` when a mutation forces the re-read |
| `soroban-balance-query-in-loop` | A read inside a loop body — repeats once per iteration even at count 1 |

```rust
// reusable → "Read the balance once into a local variable, saving 2 read(s)"
let a = client.balance(&user);
let b = client.balance(&user);
let c = client.balance(&user);

// not reusable → "Keep the re-read: a token transfer at line 4 may change this balance"
let before = client.balance(&user);
client.transfer(&user, &treasury, &fee);
let after  = client.balance(&user);
```

### 3. Shared lexical helpers

`packages/analyzers/soroban/common/source-utils.ts`

Both analyzers are lexical rather than AST-based, matching the existing Soroban
analyzers in this repo. Four pieces of infrastructure are shared rather than
duplicated:

- **Offset-preserving masking** — comments and string/char literals are blanked
  to spaces so regex scanning can't match inside them, while every index still
  addresses the original source. Rust lifetimes (`&'a str`) are not mistaken for
  char literals, and nested `/* /* */ */` block comments are handled.
- **Balanced-paren argument extraction** — call sites parse correctly when the
  argument list spans multiple lines or contains nested calls.
- **Expression normalization** — strips `&`, `*`, trailing `.clone()`, `.into()`,
  `.to_owned()` so equality checks compare identities, not spelling.
- **Block-frame tracking** — each frame carries the offset of its opening brace,
  so two sites in *different* `if` blocks are distinguishable from two sites in
  the same one. This is what makes the branch-exclusivity check correct rather
  than merely kind-based.

### 4. Rule wrappers

`packages/rules/soroban/src/tokens/` — thin wrappers following the existing
`functions/call-frequency-rule.ts` and `resources/cpu-cost-rule.ts` pattern.
Each rule exposes three entry points: all findings, the safe-to-act-on subset,
and the full structured report.

```ts
detectUnnecessaryTransfers(source)      // all findings, preserved included
detectConsolidatableTransfers(source)   // preserved filtered out
analyzeTransferGraph(source)            // sites, edges, paths, metrics

detectRedundantBalanceQueries(source)   // all findings
detectReusableBalanceQueries(source)    // safe-to-reuse only
analyzeBalanceQueryUsage(source)        // queries, groups, metrics
```

Re-exported from `packages/rules/soroban/src/index.ts` via `export * from './tokens'`.

---

## Testing

**54 new tests, all passing.**

| Suite | Tests |
|---|---|
| `callgraph/__tests__/token-transfer-analyzer.spec.ts` | 22 |
| `calls/__tests__/balance-query-analyzer.spec.ts` | 24 |
| `rules/soroban/tests/token-rules.spec.ts` | 8 |

Coverage spans extraction (both client idioms, `transfer_from` slots, clone
normalization, comment/string immunity), graph construction (edge counting,
relay tracing, cross-token isolation), every finding type, every preservation
path, and report metrics — plus empty-source and cross-function-isolation cases
on both analyzers.

```
Test Suites: 3 passed, 3 total
Tests:       54 passed, 54 total
```

**Static checks**

- `tsc --noEmit --strict` — clean on all new sources and specs.
- `eslint` — 0 errors. Prettier quote-style warnings match the existing baseline
  (`call-frequency-analyzer.ts` emits 16 of the same on `main`).

**Pre-existing failures, not introduced here**

Four suites under `packages/analyzers/soroban/` fail — `storage-analyzer`,
`redundant-write`, `lifetime-analyzer`, `cpu-cost-estimator`. I checked out
`main` and reproduced the identical 3 test failures there. They are untouched by
this change.

---

## Notes for reviewers

- **Rule directory.** The issues named `packages/rules/soroban/tokens/`, but every
  existing rule in this package lives under `packages/rules/soroban/src/<area>/`.
  I followed the existing convention and used `src/tokens/`. Happy to move it if
  the flat path was deliberate.
- **Lexical, not AST.** Consistent with the other Soroban analyzers here. The
  masking and balanced-paren helpers close the usual gaps (literals, comments,
  multi-line calls); a `Client` aliased through an intermediate variable or
  returned from a helper will not resolve its token, and is reported under the
  receiver name instead of the underlying address.
- **Bias toward silence.** Where safety is uncertain the analyzers downgrade to
  `info` and explain, rather than staying quiet or suggesting a risky merge. The
  `detectConsolidatable*` / `detectReusable*` entry points exist so a caller that
  wants only actionable findings never has to inspect the `preserved` flag itself.
