### PR TITLE
feat(soroban/auth): detect unchecked authentication parameters (#897)

### DIFF
--- a/packages/analyzers/soroban/security/__tests__/unchecked-auth-parameter-analyzer.spec.ts
+++ b/packages/analyzers/soroban/security/__tests__/unchecked-auth-parameter-analyzer.spec.ts
@@ -1,0 +1,274 @@
+import {
+  analyzeUncheckedAuthParameters,
+  UncheckedAuthParameterAnalyzer,
+} from '../unchecked-auth-parameter-analyzer';
+
+describe('UncheckedAuthParameterAnalyzer (Issue #897)', () => {
+  const analyzer = new UncheckedAuthParameterAnalyzer();
+
+  describe('1. Clearly unchecked authentication parameters (should flag)', () => {
+    it('detects unchecked "from" address in token transfer', () => {
+      const src = `
+use soroban_sdk::{contractimpl, Address, Env};
+
+pub struct VaultContract;
+
+#[contractimpl]
+impl VaultContract {
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        let client = token::Client::new(&env, &token);
+        client.transfer(&from, &to, &amount);
+    }
+}
+`;
+      const report = analyzer.analyzeWithReport(src);
+      expect(report.findings.length).toBeGreaterThanOrEqual(1);
+
+      const finding = report.findings.find(
+        (f) => f.functionName === 'transfer' && f.parameterName === 'from',
+      );
+      expect(finding).toBeDefined();
+      expect(finding?.severity).toBe('high');
+      expect(finding?.rule).toBe('A4-unchecked-auth-param');
+      expect(finding?.ruleId).toBe('soroban-unchecked-auth-parameter');
+      expect(finding?.details.issueType).toBe('missing_validation');
+      expect(report.metrics.uncheckedParameters).toBeGreaterThanOrEqual(1);
+    });
+
+    it('detects unchecked caller/admin in privileged storage mutation', () => {
+      const src = `
+use soroban_sdk::{contractimpl, Address, Env};
+
+pub struct AdminContract;
+
+#[contractimpl]
+impl AdminContract {
+    pub fn update_admin(env: Env, caller: Address, new_admin: Address) {
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+    }
+}
+`;
+      const findings = analyzeUncheckedAuthParameters(src).findings;
+      const callerFinding = findings.find((f) => f.parameterName === 'caller');
+      expect(callerFinding).toBeDefined();
+      expect(callerFinding?.details.issueType).toBe('missing_validation');
+    });
+
+    it('detects unchecked signer in token burn', () => {
+      const src = `
+pub fn burn_tokens(env: Env, account: Address, amount: i128) {
+    let client = token::Client::new(&env, &token_addr);
+    client.burn(&account, &amount);
+}
+`;
+      const findings = analyzer.analyze(src);
+      expect(findings.some((f) => f.parameterName === 'account')).toBe(true);
+    });
+  });
+
+  describe('2. Properly validated authentication parameters (should not flag)', () => {
+    it('does not flag when require_auth precedes the transfer', () => {
+      const src = `
+use soroban_sdk::{contractimpl, Address, Env};
+
+pub struct TokenContract;
+
+#[contractimpl]
+impl TokenContract {
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+        let client = token::Client::new(&env, &token);
+        client.transfer(&from, &to, &amount);
+    }
+}
+`;
+      const findings = analyzeUncheckedAuthParameters(src).findings;
+      expect(findings.length).toBe(0);
+    });
+
+    it('does not flag when require_auth_for_args is used', () => {
+      const src = `
+pub fn transfer_with_context(env: Env, from: Address, to: Address, amount: i128) {
+    from.require_auth_for_args((&to, &amount).into_val(&env));
+    let client = token::Client::new(&env, &token);
+    client.transfer(&from, &to, &amount);
+}
+`;
+      const findings = analyzer.analyze(src);
+      expect(findings.length).toBe(0);
+    });
+
+    it('recognizes equality assertion as valid authorization guard', () => {
+      const src = `
+pub fn set_fees(env: Env, admin: Address, new_fee: u32) {
+    let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+    assert!(admin == stored_admin, "Unauthorized");
+    env.storage().instance().set(&DataKey::Fee, &new_fee);
+}
+`;
+      const findings = analyzer.analyze(src);
+      expect(findings.length).toBe(0);
+    });
+
+    it('recognizes cryptographic signature verification as valid authorization', () => {
+      const src = `
+pub fn execute_signed(env: Env, signer: Address, sig: BytesN<64>, msg: Bytes) {
+    env.crypto().ed25519_verify(&sig, &msg, &signer);
+    env.storage().instance().set(&DataKey::Executed, &true);
+}
+`;
+      const findings = analyzer.analyze(src);
+      expect(findings.length).toBe(0);
+    });
+  });
+
+  describe('3. Parameter checked ONLY AFTER use (order hazard, should flag)', () => {
+    it('flags when transfer happens before require_auth call', () => {
+      const src = `
+use soroban_sdk::{contractimpl, Address, Env};
+
+pub struct FlawedContract;
+
+#[contractimpl]
+impl FlawedContract {
+    pub fn withdraw(env: Env, user: Address, to: Address, amount: i128) {
+        let client = token::Client::new(&env, &token);
+        client.transfer(&user, &to, &amount);
+        user.require_auth();
+    }
+}
+`;
+      const report = analyzer.analyzeWithReport(src);
+      expect(report.findings.length).toBe(1);
+
+      const finding = report.findings[0];
+      expect(finding.parameterName).toBe('user');
+      expect(finding.details.issueType).toBe('checked_after_use');
+      expect(finding.message).toMatch(/before being authorized/i);
+      expect(finding.suggestion).toMatch(/Move the authorization check/i);
+      expect(report.metrics.misorderedChecks).toBe(1);
+    });
+
+    it('flags when storage mutation happens before require_auth call', () => {
+      const src = `
+pub fn pause_protocol(env: Env, admin: Address) {
+    env.storage().instance().set(&DataKey::Paused, &true);
+    admin.require_auth();
+}
+`;
+      const findings = analyzer.analyze(src);
+      expect(findings.length).toBe(1);
+      expect(findings[0].details.issueType).toBe('checked_after_use');
+    });
+  });
+
+  describe('4. Destination parameters and non-authorizing roles (should not flag)', () => {
+    it('does not flag the destination "to" parameter when "from" is authorized', () => {
+      const src = `
+pub fn pay_invoice(env: Env, from: Address, to: Address, amount: i128) {
+    from.require_auth();
+    let client = token::Client::new(&env, &token);
+    client.transfer(&from, &to, &amount);
+}
+`;
+      const findings = analyzer.analyze(src);
+      expect(findings.length).toBe(0);
+    });
+
+    it('does not flag token contract address parameter used to create client', () => {
+      const src = `
+pub fn sweep(env: Env, owner: Address, token: Address, recipient: Address, amount: i128) {
+    owner.require_auth();
+    let client = token::Client::new(&env, &token);
+    client.transfer(&owner, &recipient, &amount);
+}
+`;
+      const findings = analyzer.analyze(src);
+      expect(findings.length).toBe(0);
+    });
+  });
+
+  describe('5. Excludes public read-only views and getters', () => {
+    it('skips public view functions even with Address parameter', () => {
+      const src = `
+pub fn get_user_balance(env: Env, user: Address) -> i128 {
+    env.storage().persistent().get(&user).unwrap_or(0)
+}
+
+pub fn view_allowance(env: Env, owner: Address, spender: Address) -> i128 {
+    1000
+}
+
+#[view]
+pub fn check_status(env: Env, account: Address) -> bool {
+    true
+}
+`;
+      const findings = analyzer.analyze(src);
+      expect(findings.length).toBe(0);
+    });
+  });
+
+  describe('6. Realistic multi-function Soroban contract fixture', () => {
+    const REALISTIC_CONTRACT = `
+use soroban_sdk::{contractimpl, Address, Env, BytesN};
+
+pub struct DeFiVault;
+
+#[contractimpl]
+impl DeFiVault {
+    // 1. Properly authorized deposit
+    pub fn deposit(env: Env, from: Address, amount: i128) {
+        from.require_auth();
+        let client = token::Client::new(&env, &token);
+        client.transfer(&from, &env.current_contract_address(), &amount);
+        env.storage().persistent().set(&DataKey::Balance(from), &amount);
+    }
+
+    // 2. Vulnerability: Unchecked "caller" updating protocol fee
+    pub fn set_fee(env: Env, caller: Address, fee_bps: u32) {
+        env.storage().instance().set(&DataKey::Fee, &fee_bps);
+    }
+
+    // 3. Vulnerability: Order hazard - transfer occurs BEFORE require_auth
+    pub fn emergency_withdraw(env: Env, user: Address, to: Address, amount: i128) {
+        let client = token::Client::new(&env, &token);
+        client.transfer(&user, &to, &amount);
+        user.require_auth();
+    }
+
+    // 4. Properly authorized admin action with equality check
+    pub fn set_admin(env: Env, admin: Address, new_admin: Address) {
+        let current_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        assert_eq!(admin, current_admin);
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+    }
+
+    // 5. Read-only query (should not flag)
+    pub fn get_fee(env: Env) -> u32 {
+        env.storage().instance().get(&DataKey::Fee).unwrap_or(0)
+    }
+}
+`;
+
+    it('correctly audits the realistic contract fixture', () => {
+      const report = analyzer.analyzeWithReport(REALISTIC_CONTRACT);
+
+      expect(report.metrics.validatedParameters).toBe(2); // deposit (from), set_admin (admin)
+      expect(report.metrics.uncheckedParameters).toBe(1); // set_fee (caller)
+      expect(report.metrics.misorderedChecks).toBe(1); // emergency_withdraw (user)
+
+      expect(report.findings).toHaveLength(2);
+
+      const uncheckedFinding = report.findings.find((f) => f.functionName === 'set_fee');
+      expect(uncheckedFinding).toBeDefined();
+      expect(uncheckedFinding?.parameterName).toBe('caller');
+      expect(uncheckedFinding?.details.issueType).toBe('missing_validation');
+
+      const misorderedFinding = report.findings.find((f) => f.functionName === 'emergency_withdraw');
+      expect(misorderedFinding).toBeDefined();
+      expect(misorderedFinding?.parameterName).toBe('user');
+      expect(misorderedFinding?.details.issueType).toBe('checked_after_use');
+    });
+  });
+});

--- a/packages/analyzers/soroban/security/index.ts
+++ b/packages/analyzers/soroban/security/index.ts
@@ -1,1 +1,2 @@
 export * from './missing-authorization-analyzer';
+export * from './unchecked-auth-parameter-analyzer';

--- a/packages/analyzers/soroban/security/unchecked-auth-parameter-analyzer.ts
+++ b/packages/analyzers/soroban/security/unchecked-auth-parameter-analyzer.ts
@@ -1,0 +1,493 @@
+/**
+ * Issue #897 — Detect Unchecked Authentication Parameters
+ *
+ * Detects authentication inputs in Soroban smart contracts that are used to gate
+ * or execute privileged operations without sufficient preceding validation.
+ * Flags missing require_auth calls and order-of-execution hazards (checks occurring
+ * after privileged use).
+ */
+
+import {
+  maskNonCode,
+  extractFunctions as extractCommonFunctions,
+  createLineResolver,
+  splitArgs,
+  normalizeExpr,
+} from '../common/source-utils';
+
+export type Severity = 'critical' | 'high' | 'medium' | 'low';
+
+export interface UncheckedAuthParamFinding {
+  ruleId: 'soroban-unchecked-auth-parameter';
+  rule: 'A4-unchecked-auth-param';
+  severity: Severity;
+  line: number;
+  functionName: string;
+  parameterName: string;
+  message: string;
+  suggestion: string;
+  location: {
+    line: number;
+    functionName: string;
+    column?: number;
+  };
+  details: {
+    functionName: string;
+    parameterName: string;
+    issueType: 'missing_validation' | 'checked_after_use';
+    privilegedUseLine: number;
+    validationLine?: number;
+    privilegedAction: string;
+  };
+}
+
+export interface UncheckedAuthParamReport {
+  findings: UncheckedAuthParamFinding[];
+  metrics: {
+    totalAuthParameters: number;
+    uncheckedParameters: number;
+    misorderedChecks: number;
+    validatedParameters: number;
+  };
+}
+
+export interface FunctionParam {
+  name: string;
+  typeName: string;
+  isAddress: boolean;
+  isAuthCandidate: boolean;
+}
+
+export interface ParsedFunction {
+  name: string;
+  startLine: number;
+  fnStartOffset: number;
+  bodyStartOffset: number;
+  bodyEndOffset: number;
+  header: string;
+  body: string;
+  params: FunctionParam[];
+  isSensitive: boolean;
+}
+
+/** Names / attributes treated as intentionally public getters (false-positive reduction). */
+const PUBLIC_ALLOWLIST =
+  /\b(get_|read_|view_|query_|list_|fetch_|is_|has_|balance_of|total_|version|name|symbol|decimals)\w*\b/i;
+
+const PUBLIC_ATTR = /#\[\s*(view|readonly|public|contractmeta|contractevent)\s*\]/i;
+
+/** Parameter names strongly indicating authentication roles. */
+const AUTH_PARAM_NAMES =
+  /\b(from|caller|owner|admin|sender|user|account|signer|auth|authority|delegator|initiator|operator|spender|payer|guardian|master|source)\b/i;
+
+/** Parameter names representing passive recipients / new values / non-authorizing targets. */
+const RECIPIENT_PARAM_NAMES =
+  /\b(to|recipient|receiver|target|dest|destination|new_\w+|new[A-Z]\w*)\b/i;
+
+/** State mutation indicators in Soroban. */
+const STORAGE_WRITE_RE =
+  /(?:env\s*\.\s*)?storage\s*\(\s*\)\s*\.\s*(?:instance|persistent|temporary)\s*\(\s*\)\s*\.\s*(?:set|remove|update|extend_ttl)\s*\(/g;
+
+/** General sensitive function names. */
+const SENSITIVE_FN_NAME =
+  /\b(set|update|write|store|mint|burn|transfer|withdraw|deposit|approve|revoke|pause|unpause|upgrade|admin|init|initialize|create|delete|remove|claim|stake|unstake|execute|finalize)\w*\b/i;
+
+/**
+ * Extracts functions, attributes, signatures, and typed parameters from Soroban Rust source.
+ */
+export function extractContractFunctions(source: string): ParsedFunction[] {
+  const masked = maskNonCode(source);
+  const lineOf = createLineResolver(source);
+  const rawBlocks = extractCommonFunctions(masked, source);
+  const functions: ParsedFunction[] = [];
+
+  const fnSignatureRe = /\bfn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)/g;
+
+  for (const block of rawBlocks) {
+    fnSignatureRe.lastIndex = 0;
+    // Find the signature right before bodyStart
+    const preBody = masked.slice(Math.max(0, block.bodyStart - 300), block.bodyStart);
+    const attrWindow = source.slice(Math.max(0, block.bodyStart - 400), block.bodyStart);
+
+    let match: RegExpExecArray | null;
+    let foundSig: { name: string; paramsRaw: string; sigOffset: number } | null = null;
+
+    while ((match = fnSignatureRe.exec(preBody)) !== null) {
+      if (match[1] === block.name) {
+        foundSig = {
+          name: match[1],
+          paramsRaw: match[2],
+          sigOffset: Math.max(0, block.bodyStart - 300) + match.index,
+        };
+      }
+    }
+
+    const params: FunctionParam[] = [];
+    if (foundSig) {
+      const rawParamList = splitArgs(foundSig.paramsRaw);
+      for (const rawParam of rawParamList) {
+        // Parse "name: Type" or "mut name: Type"
+        const parts = rawParam.split(':');
+        if (parts.length < 2) continue;
+
+        const name = parts[0].replace(/\bmut\s+/, '').trim();
+        const typeName = parts.slice(1).join(':').trim();
+
+        if (name === 'env' || name === '&env' || name === '_env' || name === 'self' || name === '&self') {
+          continue;
+        }
+
+        const isAddress = /\bAddress\b/.test(typeName) || /^&?Address\b/.test(typeName);
+        const isAuthCandidate =
+          isAddress ||
+          AUTH_PARAM_NAMES.test(name) ||
+          (!RECIPIENT_PARAM_NAMES.test(name) && isAddress);
+
+        params.push({
+          name,
+          typeName,
+          isAddress,
+          isAuthCandidate,
+        });
+      }
+    }
+
+    const fnBody = source.slice(block.bodyStart, block.bodyEnd);
+    const isPublic = PUBLIC_ALLOWLIST.test(block.name) || PUBLIC_ATTR.test(attrWindow);
+    const isTest = /^test_/.test(block.name);
+    const hasStorageWrite = /storage\s*\(\s*\)\s*\.\s*(?:instance|persistent|temporary)\s*\(\s*\)\s*\.\s*(?:set|remove|update)/.test(fnBody);
+    const isSensitive = !isPublic && !isTest && (SENSITIVE_FN_NAME.test(block.name) || hasStorageWrite);
+
+    functions.push({
+      name: block.name,
+      startLine: block.line,
+      fnStartOffset: foundSig ? foundSig.sigOffset : block.bodyStart,
+      bodyStartOffset: block.bodyStart,
+      bodyEndOffset: block.bodyEnd,
+      header: attrWindow,
+      body: fnBody,
+      params,
+      isSensitive,
+    });
+  }
+
+  return functions;
+}
+
+interface ValidationCheckSite {
+  paramName: string;
+  offset: number;
+  line: number;
+  kind: string;
+}
+
+interface PrivilegedUsageSite {
+  paramName: string;
+  offset: number;
+  line: number;
+  actionDescription: string;
+}
+
+/**
+ * Finds all validation / authorization checks on a parameter within a function body.
+ */
+function findValidationChecks(
+  paramName: string,
+  fnBody: string,
+  bodyStartOffset: number,
+  lineOf: (offset: number) => number,
+): ValidationCheckSite[] {
+  const checks: ValidationCheckSite[] = [];
+  const p = escapeRegex(paramName);
+
+  const patterns: Array<{ re: RegExp; kind: string }> = [
+    // param.require_auth() or param.require_auth_for_args(...)
+    {
+      re: new RegExp(`\\b${p}\\s*\\.\\s*(require_auth|require_auth_for_args)\\s*\\(`, 'g'),
+      kind: 'require_auth',
+    },
+    // require_auth(&param) or env.require_auth(&param)
+    {
+      re: new RegExp(`(?:env\\s*\\.\\s*)?require_auth(?:_for_args)?\\s*\\(\\s*&?\\s*${p}\\b`, 'g'),
+      kind: 'require_auth_call',
+    },
+    // auth.authenticate(&param) or check_auth(&param) or assert_auth(&param)
+    {
+      re: new RegExp(`(?:auth\\s*\\.\\s*)?(?:authenticate|check_auth|assert_auth|authorize_as_parent)\\s*\\(\\s*&?\\s*${p}\\b`, 'g'),
+      kind: 'auth_helper',
+    },
+    // Equality checks / assertions:
+    // assert!(param == admin) / assert_eq!(param, admin) / if param == admin / if param != admin
+    {
+      re: new RegExp(`\\bassert_eq!\\s*\\(\\s*&?\\s*${p}\\b`, 'g'),
+      kind: 'assert_eq',
+    },
+    {
+      re: new RegExp(`\\bassert_eq!\\s*\\([^,]+,\\s*&?\\s*${p}\\b`, 'g'),
+      kind: 'assert_eq',
+    },
+    {
+      re: new RegExp(`(?:assert!|if)\\s*\\(?\\s*&?\\s*${p}\\s*(?:==|!=)`, 'g'),
+      kind: 'equality_check',
+    },
+    {
+      re: new RegExp(`(?:assert!|if)\\s*\\([^)]*(?:==|!=)\\s*&?\\s*${p}\\b`, 'g'),
+      kind: 'equality_check',
+    },
+    // Custom auth guard: is_authorized(&param) or has_role(&param)
+    {
+      re: new RegExp(`\\b(?:is_authorized|has_role|is_admin|check_permission)\\s*\\(\\s*&?\\s*${p}\\b`, 'g'),
+      kind: 'role_check',
+    },
+    // Cryptographic signature verification: crypto.ed25519_verify(..., &param, ...) or verify_sig(&param, ...)
+    {
+      re: new RegExp(`(?:ed25519_verify|secp256k1_[A-Za-z0-9_]+|verify_signature|verify_sig)\\s*\\([^)]*&?\\s*${p}\\b`, 'g'),
+      kind: 'signature_verify',
+    },
+  ];
+
+  for (const { re, kind } of patterns) {
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(fnBody)) !== null) {
+      const absOffset = bodyStartOffset + m.index;
+      checks.push({
+        paramName,
+        offset: absOffset,
+        line: lineOf(absOffset),
+        kind,
+      });
+    }
+  }
+
+  return checks.sort((a, b) => a.offset - b.offset);
+}
+
+/**
+ * Finds privileged / sensitive actions where the parameter is acting as authorizer or source.
+ */
+function findPrivilegedUsages(
+  param: FunctionParam,
+  fn: ParsedFunction,
+  source: string,
+  lineOf: (offset: number) => number,
+): PrivilegedUsageSite[] {
+  const usages: PrivilegedUsageSite[] = [];
+  const fnBody = fn.body;
+  const p = escapeRegex(param.name);
+
+  // 1. Token transfer/burn where param is the source/debited account:
+  // e.g. client.transfer(&from, &to, &amount) or token.burn(&from, &amount)
+  const tokenOpPatterns = [
+    {
+      re: new RegExp(`\\.\\s*(?:transfer|transfer_from|burn)\\s*\\(\\s*&?\\s*${p}\\b`, 'g'),
+      desc: `Token debit/transfer from '${param.name}'`,
+    },
+    {
+      re: new RegExp(`token::Client::[^;]+\\.\\s*(?:transfer|transfer_from|burn)\\s*\\(\\s*&?\\s*${p}\\b`, 'g'),
+      desc: `Token client transfer from '${param.name}'`,
+    },
+  ];
+
+  for (const { re, desc } of tokenOpPatterns) {
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(fnBody)) !== null) {
+      const absOffset = fn.bodyStartOffset + m.index;
+      usages.push({
+        paramName: param.name,
+        offset: absOffset,
+        line: lineOf(absOffset),
+        actionDescription: desc,
+      });
+    }
+  }
+
+  // 2. Sensitive state storage writes gated or parameterized by param:
+  // e.g. env.storage().instance().set(&DataKey::Admin, &param) or modifying state when param is caller/admin
+  const isAuthRoleName = AUTH_PARAM_NAMES.test(param.name);
+  if (fn.isSensitive || isAuthRoleName) {
+    STORAGE_WRITE_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = STORAGE_WRITE_RE.exec(fnBody)) !== null) {
+      const absOffset = fn.bodyStartOffset + m.index;
+      usages.push({
+        paramName: param.name,
+        offset: absOffset,
+        line: lineOf(absOffset),
+        actionDescription: `State modification in sensitive function '${fn.name}'`,
+      });
+    }
+  }
+
+  // 3. Admin / role updates or privileged invocations
+  const privilegedCallRe = new RegExp(`\\b(?:set_admin|update_admin|pause|unpause|upgrade|mint|withdraw|emergency_withdraw)\\s*\\(`, 'g');
+  let pm: RegExpExecArray | null;
+  while ((pm = privilegedCallRe.exec(fnBody)) !== null) {
+    const absOffset = fn.bodyStartOffset + pm.index;
+    usages.push({
+      paramName: param.name,
+      offset: absOffset,
+      line: lineOf(absOffset),
+      actionDescription: `Privileged function invocation '${pm[0].replace('(', '')}'`,
+    });
+  }
+
+  // Deduplicate usages at the same line
+  const uniqueUsages: PrivilegedUsageSite[] = [];
+  const seenLines = new Set<number>();
+
+  for (const u of usages.sort((a, b) => a.offset - b.offset)) {
+    if (!seenLines.has(u.line)) {
+      seenLines.add(u.line);
+      uniqueUsages.push(u);
+    }
+  }
+
+  return uniqueUsages;
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Analyzes Soroban smart contract source code for unchecked authentication parameters.
+ */
+export function analyzeUncheckedAuthParameters(sourceCode: string): UncheckedAuthParamReport {
+  const functions = extractContractFunctions(sourceCode);
+  const lineOf = createLineResolver(sourceCode);
+  const findings: UncheckedAuthParamFinding[] = [];
+
+  let totalAuthParameters = 0;
+  let uncheckedParameters = 0;
+  let misorderedChecks = 0;
+  let validatedParameters = 0;
+
+  for (const fn of functions) {
+    // Skip view/read-only functions
+    if (!fn.isSensitive && PUBLIC_ALLOWLIST.test(fn.name)) {
+      continue;
+    }
+
+    for (const param of fn.params) {
+      // Determine if parameter is an authentication parameter candidate
+      // We skip parameters that are clearly passive recipients unless they are being debited
+      if (RECIPIENT_PARAM_NAMES.test(param.name) && !AUTH_PARAM_NAMES.test(param.name)) {
+        // Recipient target in transfer: check if it's used as debited source
+        const isDebited = new RegExp(`\\.\\s*(?:transfer|transfer_from|burn)\\s*\\(\\s*&?\\s*${escapeRegex(param.name)}\\b`).test(fn.body);
+        if (!isDebited) {
+          continue;
+        }
+      }
+
+      if (!param.isAuthCandidate && !param.isAddress) {
+        continue;
+      }
+
+      // Check if parameter is a token contract instance parameter (e.g. token: Address passed into Client::new)
+      if (param.name === 'token' || param.name === 'token_address') {
+        const isOnlyTokenClient = new RegExp(`Client::new\\s*\\([^)]*&?\\s*${escapeRegex(param.name)}\\b`).test(fn.body);
+        const isDebited = new RegExp(`\\.\\s*transfer\\s*\\(\\s*&?\\s*${escapeRegex(param.name)}\\b`).test(fn.body);
+        if (isOnlyTokenClient && !isDebited) {
+          continue;
+        }
+      }
+
+      const validationChecks = findValidationChecks(param.name, fn.body, fn.bodyStartOffset, lineOf);
+      const privilegedUsages = findPrivilegedUsages(param, fn, sourceCode, lineOf);
+
+      // If no privileged actions in this function, no auth required
+      if (privilegedUsages.length === 0) {
+        continue;
+      }
+
+      totalAuthParameters++;
+
+      const firstValidation = validationChecks[0];
+      const firstPrivilegedUse = privilegedUsages[0];
+
+      if (!firstValidation) {
+        // Missing validation entirely
+        uncheckedParameters++;
+        findings.push({
+          ruleId: 'soroban-unchecked-auth-parameter',
+          rule: 'A4-unchecked-auth-param',
+          severity: 'high',
+          line: firstPrivilegedUse.line,
+          functionName: fn.name,
+          parameterName: param.name,
+          message:
+            `Authentication parameter '${param.name}' in '${fn.name}' is used in privileged operation ` +
+            `(${firstPrivilegedUse.actionDescription}) at line ${firstPrivilegedUse.line} without validation.`,
+          suggestion:
+            `Add \`${param.name}.require_auth()\` (or an explicit authorization check) at the entry of ` +
+            `'${fn.name}' before executing privileged operations.`,
+          location: {
+            line: firstPrivilegedUse.line,
+            functionName: fn.name,
+          },
+          details: {
+            functionName: fn.name,
+            parameterName: param.name,
+            issueType: 'missing_validation',
+            privilegedUseLine: firstPrivilegedUse.line,
+            privilegedAction: firstPrivilegedUse.actionDescription,
+          },
+        });
+      } else if (firstPrivilegedUse.offset < firstValidation.offset) {
+        // Order hazard: Privileged action executed BEFORE validation check!
+        misorderedChecks++;
+        findings.push({
+          ruleId: 'soroban-unchecked-auth-parameter',
+          rule: 'A4-unchecked-auth-param',
+          severity: 'high',
+          line: firstPrivilegedUse.line,
+          functionName: fn.name,
+          parameterName: param.name,
+          message:
+            `Authentication parameter '${param.name}' in '${fn.name}' is used in a privileged operation at line ` +
+            `${firstPrivilegedUse.line} before being authorized at line ${firstValidation.line}.`,
+          suggestion:
+            `Move the authorization check \`${param.name}.require_auth()\` from line ${firstValidation.line} ` +
+            `to the beginning of '${fn.name}' prior to line ${firstPrivilegedUse.line}.`,
+          location: {
+            line: firstPrivilegedUse.line,
+            functionName: fn.name,
+          },
+          details: {
+            functionName: fn.name,
+            parameterName: param.name,
+            issueType: 'checked_after_use',
+            privilegedUseLine: firstPrivilegedUse.line,
+            validationLine: firstValidation.line,
+            privilegedAction: firstPrivilegedUse.actionDescription,
+          },
+        });
+      } else {
+        // Properly validated before privileged use
+        validatedParameters++;
+      }
+    }
+  }
+
+  return {
+    findings,
+    metrics: {
+      totalAuthParameters,
+      uncheckedParameters,
+      misorderedChecks,
+      validatedParameters,
+    },
+  };
+}
+
+export class UncheckedAuthParameterAnalyzer {
+  public static readonly RULE_ID = 'soroban-unchecked-auth-parameter';
+
+  public analyze(sourceCode: string): UncheckedAuthParamFinding[] {
+    return analyzeUncheckedAuthParameters(sourceCode).findings;
+  }
+
+  public analyzeWithReport(sourceCode: string): UncheckedAuthParamReport {
+    return analyzeUncheckedAuthParameters(sourceCode);
+  }
+}

--- a/packages/rules/soroban/auth/index.ts
+++ b/packages/rules/soroban/auth/index.ts
@@ -1,0 +1,1 @@
+export * from './unchecked-auth-parameter.rule';

--- a/packages/rules/soroban/auth/unchecked-auth-parameter.rule.ts
+++ b/packages/rules/soroban/auth/unchecked-auth-parameter.rule.ts
@@ -1,0 +1,95 @@
+/**
+ * Rule: soroban-unchecked-auth-parameter (#897)
+ * Detects authentication inputs used without sufficient validation.
+ */
+
+import {
+  analyzeUncheckedAuthParameters,
+  UncheckedAuthParameterAnalyzer,
+} from '../../../analyzers/soroban/security/unchecked-auth-parameter-analyzer';
+import type {
+  UncheckedAuthParamFinding,
+  UncheckedAuthParamReport,
+} from '../../../analyzers/soroban/security/unchecked-auth-parameter-analyzer';
+
+export interface UncheckedAuthRuleFinding {
+  ruleId: 'soroban-unchecked-auth-parameter';
+  rule: 'A4-unchecked-auth-param';
+  severity: 'critical' | 'high' | 'medium' | 'low';
+  line: number;
+  functionName: string;
+  parameterName: string;
+  message: string;
+  suggestion: string;
+  location: {
+    line: number;
+    functionName: string;
+    column?: number;
+  };
+  details: {
+    functionName: string;
+    parameterName: string;
+    issueType: 'missing_validation' | 'checked_after_use';
+    privilegedUseLine: number;
+    validationLine?: number;
+    privilegedAction: string;
+  };
+}
+
+export interface UncheckedAuthRuleReport {
+  findings: UncheckedAuthRuleFinding[];
+  summary: string;
+  metrics: {
+    totalAuthParameters: number;
+    uncheckedParameters: number;
+    misorderedChecks: number;
+    validatedParameters: number;
+  };
+}
+
+/**
+ * Detect unchecked authentication parameters in Soroban smart contract source code.
+ */
+export function detectUncheckedAuthParameters(source: string): UncheckedAuthRuleReport {
+  const analysis: UncheckedAuthParamReport = analyzeUncheckedAuthParameters(source);
+  return convertToRuleReport(analysis);
+}
+
+/**
+ * Convert analyzer report to rule report format.
+ */
+function convertToRuleReport(analysis: UncheckedAuthParamReport): UncheckedAuthRuleReport {
+  const findings: UncheckedAuthRuleFinding[] = analysis.findings.map((finding) => ({
+    ruleId: 'soroban-unchecked-auth-parameter' as const,
+    rule: 'A4-unchecked-auth-param' as const,
+    severity: finding.severity,
+    line: finding.line,
+    functionName: finding.functionName,
+    parameterName: finding.parameterName,
+    message: finding.message,
+    suggestion: finding.suggestion,
+    location: finding.location,
+    details: finding.details,
+  }));
+
+  const unchecked = analysis.metrics.uncheckedParameters;
+  const misordered = analysis.metrics.misorderedChecks;
+  const summary =
+    unchecked === 0 && misordered === 0
+      ? 'All authentication parameters are properly validated before privileged use.'
+      : `Found ${unchecked} unchecked authentication parameter(s) and ${misordered} misordered check(s).`;
+
+  return {
+    findings,
+    summary,
+    metrics: analysis.metrics,
+  };
+}
+
+export class UncheckedAuthParameterRule {
+  public static readonly RULE_ID = 'soroban-unchecked-auth-parameter';
+
+  public evaluate(sourceCode: string): UncheckedAuthRuleReport {
+    return detectUncheckedAuthParameters(sourceCode);
+  }
+}

--- a/packages/rules/soroban/src/authorization/index.ts
+++ b/packages/rules/soroban/src/authorization/index.ts
@@ -1,2 +1,3 @@
 export * from './authorization-analyzer';
 export * from './missing-authorization-analyzer';
+export * from './unchecked-auth-parameter-analyzer';

--- a/packages/rules/soroban/src/authorization/unchecked-auth-parameter-analyzer.ts
+++ b/packages/rules/soroban/src/authorization/unchecked-auth-parameter-analyzer.ts
@@ -1,0 +1,8 @@
+/**
+ * Issue #897 — Detect Unchecked Authentication Parameters
+ *
+ * Mirror of packages/analyzers/soroban/security/unchecked-auth-parameter-analyzer.ts
+ * kept local so the rules package does not depend on TS path aliases.
+ */
+
+export * from '../../../../analyzers/soroban/security/unchecked-auth-parameter-analyzer';

--- a/packages/rules/soroban/src/index.ts
+++ b/packages/rules/soroban/src/index.ts
@@ -18,3 +18,4 @@ export * from './wasm';
 export * from './storage';
 export * from './suggestions';
 export * from '../ledger';
+export * from '../auth';

--- a/packages/rules/soroban/tests/unchecked-auth-parameter-rules.spec.ts
+++ b/packages/rules/soroban/tests/unchecked-auth-parameter-rules.spec.ts
@@ -1,0 +1,52 @@
+import {
+  detectUncheckedAuthParameters,
+  UncheckedAuthParameterRule,
+} from '../auth/unchecked-auth-parameter.rule';
+import {
+  analyzeUncheckedAuthParameters,
+  UncheckedAuthParameterAnalyzer,
+} from '../src/authorization/unchecked-auth-parameter-analyzer';
+
+describe('Soroban Unchecked Auth Parameter Rule (Issue #897)', () => {
+  const rule = new UncheckedAuthParameterRule();
+
+  it('reports unchecked parameter via rule evaluation', () => {
+    const src = `
+fn transfer_funds(env: Env, from: Address, to: Address, amount: i128) {
+    let client = token::Client::new(&env, &token);
+    client.transfer(&from, &to, &amount);
+}
+`;
+    const report = rule.evaluate(src);
+    expect(report.findings.length).toBe(1);
+    expect(report.findings[0].ruleId).toBe('soroban-unchecked-auth-parameter');
+    expect(report.findings[0].rule).toBe('A4-unchecked-auth-param');
+    expect(report.findings[0].parameterName).toBe('from');
+    expect(report.findings[0].severity).toBe('high');
+    expect(report.summary).toMatch(/1 unchecked/i);
+  });
+
+  it('reports clean report summary when all auth parameters are valid', () => {
+    const src = `
+fn transfer_funds(env: Env, from: Address, to: Address, amount: i128) {
+    from.require_auth();
+    let client = token::Client::new(&env, &token);
+    client.transfer(&from, &to, &amount);
+}
+`;
+    const report = detectUncheckedAuthParameters(src);
+    expect(report.findings.length).toBe(0);
+    expect(report.summary).toMatch(/properly validated/i);
+  });
+
+  it('re-exported analyzer in authorization module functions identically', () => {
+    const src = `
+fn update_owner(env: Env, new_owner: Address, current_owner: Address) {
+    env.storage().instance().set(&DataKey::Owner, &new_owner);
+}
+`;
+    const findings = new UncheckedAuthParameterAnalyzer().analyze(src);
+    expect(findings.length).toBe(1);
+    expect(findings[0].parameterName).toBe('current_owner');
+  });
+});


### PR DESCRIPTION
Closes #897

---

#897 Detect Unchecked Authentication Parameters
- Identify authentication parameters in Soroban contract code
- Track parameter usage through function flow
- Detect missing validation before privileged use
- Generate security findings with severity and location
- Add tests covering checked/unchecked/mis-ordered auth cases